### PR TITLE
Support for BlockParams

### DIFF
--- a/source/Handlebars.Test/BasicIntegrationTests.cs
+++ b/source/Handlebars.Test/BasicIntegrationTests.cs
@@ -144,18 +144,9 @@ false
                 }
             };
 
-            try
-            {
-                template(data);
-            }
-            catch (HandlebarsUndefinedBindingException ex)
-            {
-                Assert.Equal("person.lastname", ex.Path);
-                Assert.Equal("lastname", ex.MissingKey);
-                return;
-            }
-
-            Assert.False(true, "Exception is expected.");
+            var exception = Assert.Throws<HandlebarsUndefinedBindingException>(() => template(data));
+            Assert.Equal("person.lastname", exception.Path);
+            Assert.Equal("lastname", exception.MissingKey);
         }
 
         [Fact]
@@ -365,6 +356,23 @@ false
             var result = template(data);
             Assert.Equal("Hello, my good friend Erik!", result);
         }
+        
+        [Fact]
+        public void WithWithBlockParams()
+        {
+            var source = "{{#with person as |person|}}{{person.name}} is {{age}} years old{{/with}}.";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                person = new
+                {
+                    name = "Erik",
+                    age = 42
+                }
+            };
+            var result = template(data);
+            Assert.Equal("Erik is 42 years old.", result);
+        }
 
         [Fact]
         public void BasicWithInversion()
@@ -466,6 +474,23 @@ false
             var result = template(data);
             Assert.Equal("foo: hello bar: world ", result);
         }
+        
+        [Fact]
+        public void ObjectEnumeratorWithBlockParams()
+        {
+            var source = "{{#each enumerateMe as |item val|}}{{@item}}: {{@val}} {{/each}}";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                enumerateMe = new
+                {
+                    foo = "hello",
+                    bar = "world"
+                }
+            };
+            var result = template(data);
+            Assert.Equal("hello: foo world: bar ", result);
+        }
 
         [Fact]
         public void BasicDictionaryEnumerator()
@@ -482,6 +507,23 @@ false
             };
             var result = template(data);
             Assert.Equal("hello world ", result);
+        }
+        
+        [Fact]
+        public void DictionaryEnumeratorWithBlockParams()
+        {
+            var source = "{{#each enumerateMe as |item val|}}{{item}} {{val}} {{/each}}";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                enumerateMe = new Dictionary<string, object>
+                {
+                    { "foo", "hello"},
+                    { "bar", "world"}
+                }
+            };
+            var result = template(data);
+            Assert.Equal("hello foo world bar ", result);
         }
         
         [Fact]

--- a/source/Handlebars.Test/BasicIntegrationTests.cs
+++ b/source/Handlebars.Test/BasicIntegrationTests.cs
@@ -527,6 +527,35 @@ false
         }
         
         [Fact]
+        public void DictionaryEnumeratorWithInnerBlockParams()
+        {
+            var source = "{{#each enumerateMe as |item k|}}{{#each item as |item1 k|}}{{item1}} {{k}} {{/each}}{{/each}}";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                enumerateMe = new Dictionary<string, object>
+                {
+                    {
+                        "foo", new Dictionary<string, object>
+                        {
+                            {"foo1", "hello1"},
+                            {"bar1", "world1"}
+                        }
+                    },
+                    {
+                        "bar", new Dictionary<string, object>
+                        {
+                            {"foo2", "hello2"},
+                            {"bar2", "world2"}
+                        }
+                    }
+                }
+            };
+            var result = template(data);
+            Assert.Equal("hello1 foo1 world1 bar1 hello2 foo2 world2 bar2 ", result);
+        }
+
+        [Fact]
         public void DictionaryWithLastEnumerator()
         {
             var source = "{{#each enumerateMe}}{{@last}} {{/each}}";

--- a/source/Handlebars.Test/HelperTests.cs
+++ b/source/Handlebars.Test/HelperTests.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using HandlebarsDotNet.Compiler;
 
 namespace HandlebarsDotNet.Test
 {
@@ -25,6 +27,31 @@ namespace HandlebarsDotNet.Test
             var output = template(new { });
 
             var expected = "Here are some things: \nThing 1: foo\nThing 2: bar";
+
+            Assert.Equal(expected, output);
+        }
+        
+        [Fact]
+        public void BlockHelperWithBlockParams()
+        {
+            Handlebars.RegisterHelper("myHelper", (writer, options, context, args) => {
+                var count = 0;
+                options.BlockParams((parameters, binder) => 
+                    binder(parameters.ElementAtOrDefault(0), () => ++count));
+                
+                foreach(var arg in args)
+                {
+                    options.Template(writer, arg);
+                }
+            });
+
+            var source = "Here are some things: {{#myHelper 'foo' 'bar' as |counter|}}{{counter}}:{{this}}\n{{/myHelper}}";
+
+            var template = Handlebars.Compile(source);
+
+            var output = template(new { });
+
+            var expected = "Here are some things: 1:foo\n2:bar\n";
 
             Assert.Equal(expected, output);
         }

--- a/source/Handlebars/BuiltinHelpers.cs
+++ b/source/Handlebars/BuiltinHelpers.cs
@@ -1,12 +1,13 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Linq;
 using HandlebarsDotNet.Compiler;
 
 namespace HandlebarsDotNet
 {
-    internal static class BuiltinHelpers
+    internal class BuiltinHelpers
     {
         [Description("with")]
         public static void With(TextWriter output, HelperOptions options, dynamic context, params object[] arguments)
@@ -16,6 +17,9 @@ namespace HandlebarsDotNet
                 throw new HandlebarsException("{{with}} helper must have exactly one argument");
             }
 
+            options.BlockParams((parameters, binder) => 
+                binder(parameters.ElementAtOrDefault(0), () => arguments[0]));
+            
             if (HandlebarsUtils.IsTruthyOrNonEmpty(arguments[0]))
             {
                 options.Template(output, arguments[0]);

--- a/source/Handlebars/Compiler/ExpressionBuilder.cs
+++ b/source/Handlebars/Compiler/ExpressionBuilder.cs
@@ -21,6 +21,7 @@ namespace HandlebarsDotNet.Compiler
             tokens = LiteralConverter.Convert(tokens);
             tokens = HashParameterConverter.Convert(tokens);
             tokens = PathConverter.Convert(tokens);
+            tokens = BlockParamsConverter.Convert(tokens);
             tokens = SubExpressionConverter.Convert(tokens);
             tokens = HashParametersAccumulator.Accumulate(tokens);
             tokens = PartialConverter.Convert(tokens);

--- a/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/BlockHelperAccumulatorContext.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/BlockHelperAccumulatorContext.cs
@@ -73,7 +73,8 @@ namespace HandlebarsDotNet.Compiler
 
             var resultExpr = HandlebarsExpression.BlockHelper(
                 _startingNode.HelperName,
-                _startingNode.Arguments,
+                _startingNode.Arguments.Where(o => o.NodeType != (ExpressionType)HandlebarsExpressionType.BlockParamsExpression),
+                _startingNode.Arguments.OfType<BlockParamsExpression>().SingleOrDefault() ?? BlockParamsExpression.Empty(),
                 _accumulatedBody,
                 _accumulatedInversion,
                 _startingNode.IsRaw);

--- a/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/IteratorBlockAccumulatorContext.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/IteratorBlockAccumulatorContext.cs
@@ -25,7 +25,8 @@ namespace HandlebarsDotNet.Compiler
             if (IsElseBlock(item))
             {
                 _accumulatedExpression = HandlebarsExpression.Iterator(
-                    _startingNode.Arguments.Single(),
+                    _startingNode.Arguments.Single(o => o.NodeType != (ExpressionType)HandlebarsExpressionType.BlockParamsExpression),
+                    _startingNode.Arguments.OfType<BlockParamsExpression>().SingleOrDefault() ?? BlockParamsExpression.Empty(),
                     Expression.Block(_body));
                 _body = new List<Expression>();
             }
@@ -44,13 +45,15 @@ namespace HandlebarsDotNet.Compiler
                 if (_accumulatedExpression == null)
                 {
                     _accumulatedExpression = HandlebarsExpression.Iterator(
-                        _startingNode.Arguments.Single(),
+                        _startingNode.Arguments.Single(o => o.NodeType != (ExpressionType)HandlebarsExpressionType.BlockParamsExpression),
+                        _startingNode.Arguments.OfType<BlockParamsExpression>().SingleOrDefault() ?? BlockParamsExpression.Empty(),
                         Expression.Block(bodyStatements));
                 }
                 else
                 {
                     _accumulatedExpression = HandlebarsExpression.Iterator(
                         ((IteratorExpression)_accumulatedExpression).Sequence,
+                        ((IteratorExpression)_accumulatedExpression).BlockParams,
                         ((IteratorExpression)_accumulatedExpression).Template,
                         Expression.Block(bodyStatements));
                 }

--- a/source/Handlebars/Compiler/Lexer/Converter/BlockParamsConverter.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/BlockParamsConverter.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using HandlebarsDotNet.Compiler.Lexer;
+
+namespace HandlebarsDotNet.Compiler
+{
+    internal class BlockParamsConverter : TokenConverter
+    {
+        public static IEnumerable<object> Convert(IEnumerable<object> sequence)
+        {
+            return new BlockParamsConverter().ConvertTokens(sequence).ToList();
+        }
+
+        private BlockParamsConverter()
+        {
+        }
+
+        public override IEnumerable<object> ConvertTokens(IEnumerable<object> sequence)
+        {
+            var result = new List<object>();
+            bool foundBlockParams = false;
+            foreach (var item in sequence)
+            {
+                if (item is BlockParameterToken blockParameterToken)
+                {
+                    if(foundBlockParams) throw new HandlebarsCompilerException("multiple blockParams expressions are not supported");
+                    
+                    foundBlockParams = true;
+                    if(!(result.Last() is PathExpression pathExpression)) throw new HandlebarsCompilerException("blockParams definition has incorrect syntax");
+                    if(!string.Equals("as", pathExpression.Path, StringComparison.OrdinalIgnoreCase)) throw new HandlebarsCompilerException("blockParams definition has incorrect syntax");
+                    
+                    result[result.Count - 1] = HandlebarsExpression.BlockParams(pathExpression.Path, blockParameterToken.Value);
+                }
+                else
+                {
+                    result.Add(item);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/source/Handlebars/Compiler/Lexer/Parsers/BlockParamsParser.cs
+++ b/source/Handlebars/Compiler/Lexer/Parsers/BlockParamsParser.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace HandlebarsDotNet.Compiler.Lexer
+{
+    internal class BlockParamsParser : Parser
+    {
+        public override Token Parse(TextReader reader)
+        {
+            var buffer = AccumulateWord(reader);
+            return !string.IsNullOrEmpty(buffer) 
+                ? Token.BlockParams(buffer) 
+                : null;
+        }
+        
+        private static string AccumulateWord(TextReader reader)
+        {
+            var buffer = new StringBuilder();
+            
+            if (reader.Peek() != '|') return null;
+                
+            reader.Read();
+            
+            while (reader.Peek() != '|')
+            {
+                buffer.Append((char) reader.Read());
+            }
+
+            reader.Read();
+
+            var accumulateWord = buffer.ToString().Trim();
+            if(string.IsNullOrEmpty(accumulateWord)) throw new HandlebarsParserException($"BlockParams expression is not valid");
+            
+            return accumulateWord;
+        }
+    }
+}

--- a/source/Handlebars/Compiler/Lexer/Tokenizer.cs
+++ b/source/Handlebars/Compiler/Lexer/Tokenizer.cs
@@ -10,11 +10,12 @@ namespace HandlebarsDotNet.Compiler.Lexer
     {
         private readonly HandlebarsConfiguration _configuration;
 
-        private static Parser _wordParser = new WordParser();
-        private static Parser _literalParser = new LiteralParser();
-        private static Parser _commentParser = new CommentParser();
-        private static Parser _partialParser = new PartialParser();
-        private static Parser _blockWordParser = new BlockWordParser();
+        private static readonly Parser WordParser = new WordParser();
+        private static readonly Parser LiteralParser = new LiteralParser();
+        private static readonly Parser CommentParser = new CommentParser();
+        private static readonly Parser PartialParser = new PartialParser();
+        private static readonly Parser BlockWordParser = new BlockWordParser();
+        private static readonly Parser BlockParamsParser = new BlockParamsParser();
         //TODO: structure parser
 
         public Tokenizer(HandlebarsConfiguration configuration)
@@ -65,16 +66,17 @@ namespace HandlebarsDotNet.Compiler.Lexer
                     }
 
                     Token token = null;
-                    token = token ?? _wordParser.Parse(source);
-                    token = token ?? _literalParser.Parse(source);
-                    token = token ?? _commentParser.Parse(source);
-                    token = token ?? _partialParser.Parse(source);
-                    token = token ?? _blockWordParser.Parse(source);
+                    token = token ?? WordParser.Parse(source);
+                    token = token ?? LiteralParser.Parse(source);
+                    token = token ?? CommentParser.Parse(source);
+                    token = token ?? PartialParser.Parse(source);
+                    token = token ?? BlockWordParser.Parse(source);
+                    token = token ?? BlockParamsParser.Parse(source);
 
                     if (token != null)
                     {
                         yield return token;
-
+                            
                         if ((char)source.Peek() == '=')
                         {
                             source.Read();

--- a/source/Handlebars/Compiler/Lexer/Tokens/BlockParameterToken.cs
+++ b/source/Handlebars/Compiler/Lexer/Tokens/BlockParameterToken.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace HandlebarsDotNet.Compiler.Lexer
+{
+    internal class BlockParameterToken : Token
+    {
+        public BlockParameterToken(string value)
+        {
+            Value = value;
+        }
+        
+        public override TokenType Type
+        {
+            get { return TokenType.BlockParams; }
+        }
+
+        public override string Value { get; }
+    }
+}

--- a/source/Handlebars/Compiler/Lexer/Tokens/Token.cs
+++ b/source/Handlebars/Compiler/Lexer/Tokens/Token.cs
@@ -62,5 +62,10 @@ namespace HandlebarsDotNet.Compiler.Lexer
         {
             return new AssignmentToken();
         }
+        
+        public static BlockParameterToken BlockParams(string blockParams)
+        {
+            return new BlockParameterToken(blockParams);
+        }
     }
 }

--- a/source/Handlebars/Compiler/Lexer/Tokens/TokenType.cs
+++ b/source/Handlebars/Compiler/Lexer/Tokens/TokenType.cs
@@ -15,7 +15,8 @@ namespace HandlebarsDotNet.Compiler.Lexer
         Layout = 8,
         StartSubExpression = 9,
         EndSubExpression = 10,
-        Assignment = 11
+        Assignment = 11,
+        BlockParams = 12
     }
 }
 

--- a/source/Handlebars/Compiler/Structure/BindingContextValueProvider.cs
+++ b/source/Handlebars/Compiler/Structure/BindingContextValueProvider.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+
+namespace HandlebarsDotNet.Compiler
+{
+    internal class BindingContextValueProvider : IValueProvider
+    {
+        private readonly BindingContext _context;
+
+        public BindingContextValueProvider(BindingContext context)
+        {
+            _context = context;
+        }
+
+        public bool ProvidesNonContextVariables { get; } = false;
+
+        public bool TryGetValue(string memberName, out object value)
+        {
+            value = GetContextVariable(memberName, _context) ?? GetContextVariable(memberName, _context.Value);
+            return value != null;
+        }
+        
+        private object GetContextVariable(string variableName, object target)
+        {
+            variableName = variableName.TrimStart('@');
+            var member = target.GetType().GetMember(variableName, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            if (member.Length <= 0) return _context.ParentContext?.GetContextVariable(variableName);
+            
+            switch (member[0])
+            {
+                case PropertyInfo propertyInfo:
+                    return propertyInfo.GetValue(target, null);
+                case FieldInfo fieldInfo:
+                    return fieldInfo.GetValue(target);
+                default:
+                    throw new HandlebarsRuntimeException("Context variable references a member that is not a field or property");
+            }
+        }
+    }
+}

--- a/source/Handlebars/Compiler/Structure/BlockHelperExpression.cs
+++ b/source/Handlebars/Compiler/Structure/BlockHelperExpression.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq.Expressions;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace HandlebarsDotNet.Compiler
 {
@@ -8,6 +9,7 @@ namespace HandlebarsDotNet.Compiler
     {
         private readonly Expression _body;
         private readonly Expression _inversion;
+        private readonly BlockParamsExpression _blockParams;
 
         public BlockHelperExpression(
             string helperName,
@@ -15,10 +17,24 @@ namespace HandlebarsDotNet.Compiler
             Expression body,
             Expression inversion,
             bool isRaw = false)
+            : this(helperName, arguments, BlockParamsExpression.Empty(), body, inversion, isRaw)
+        {
+            _body = body;
+            _inversion = inversion;
+        }
+        
+        public BlockHelperExpression(
+            string helperName,
+            IEnumerable<Expression> arguments,
+            BlockParamsExpression blockParams,
+            Expression body,
+            Expression inversion,
+            bool isRaw = false)
             : base(helperName, arguments, isRaw)
         {
             _body = body;
             _inversion = inversion;
+            _blockParams = blockParams;
         }
 
         public Expression Body
@@ -29,6 +45,11 @@ namespace HandlebarsDotNet.Compiler
         public Expression Inversion
         {
             get { return _inversion; }
+        }
+
+        public BlockParamsExpression BlockParams
+        {
+            get { return _blockParams; }
         }
 
         public override ExpressionType NodeType

--- a/source/Handlebars/Compiler/Structure/BlockParamsExpression.cs
+++ b/source/Handlebars/Compiler/Structure/BlockParamsExpression.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace HandlebarsDotNet.Compiler
+{
+    internal class BlockParamsExpression : HandlebarsExpression
+    {
+        public new static BlockParamsExpression Empty() => new BlockParamsExpression(null);
+
+        private readonly BlockParam _blockParam;
+        
+        private BlockParamsExpression(BlockParam blockParam)
+        {
+            _blockParam = blockParam;
+        }
+        
+        public BlockParamsExpression(string action, string blockParams)
+            :this(new BlockParam
+            {
+                Action = action,
+                Parameters = blockParams.Split(new char[] {' '}, StringSplitOptions.RemoveEmptyEntries)
+            })
+        {
+        }
+
+        public override ExpressionType NodeType { get; } = (ExpressionType)HandlebarsExpressionType.BlockParamsExpression;
+
+        public override Type Type { get; } = typeof(BlockParam);
+
+        protected override Expression Accept(ExpressionVisitor visitor)
+        {
+            return visitor.Visit(Expression.Convert(Constant(_blockParam), typeof(BlockParam)));
+        }
+    }
+
+    internal class BlockParam
+    {
+        public string Action { get; set; }
+        public string[] Parameters { get; set; }
+    }
+}

--- a/source/Handlebars/Compiler/Structure/BlockParamsValueProvider.cs
+++ b/source/Handlebars/Compiler/Structure/BlockParamsValueProvider.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace HandlebarsDotNet.Compiler
+{
+    /// <summary/>
+    /// <param name="parameters">Parameters passed to BlockParams.</param>
+    /// <param name="valueBinder">Function that perform binding of parameter to <see cref="BindingContext"/>.</param>
+    public delegate void ConfigureBlockParams(string[] parameters, ValueBinder valueBinder);
+        
+    /// <summary>
+    /// Function that perform binding of parameter to <see cref="BindingContext"/>.
+    /// </summary>
+    /// <param name="variableName">Variable name that would be added to the <see cref="BindingContext"/>.</param>
+    /// <param name="valueProvider">Variable value provider that would be invoked when <paramref name="variableName"/> is requested.</param>
+    public delegate void ValueBinder(string variableName, Func<object> valueProvider);
+    
+    /// <summary/>
+    internal class BlockParamsValueProvider : IValueProvider
+    {
+        private readonly BlockParam _params;
+        private readonly Action<Action<BindingContext>> _invoker;
+        private readonly Dictionary<string, Func<object>> _accessors;
+
+        public BlockParamsValueProvider(BindingContext context, BlockParam @params)
+        {
+            _params = @params;
+            _invoker = action => action(context);
+            _accessors = new Dictionary<string, Func<object>>(StringComparer.OrdinalIgnoreCase);
+            
+            context.RegisterValueProvider(this);
+        }
+
+        public bool ProvidesNonContextVariables { get; } = true;
+
+        /// <summary>
+        /// Configures behavior of BlockParams.
+        /// </summary>
+        public void Configure(ConfigureBlockParams blockParamsConfiguration)
+        {
+            if(_params == null) return;
+            
+            void BlockParamsAction(BindingContext context)
+            {
+                void ValueBinder(string name, Func<object> value)
+                {
+                    if (!string.IsNullOrEmpty(name)) _accessors[name] = value;
+                }
+                
+                blockParamsConfiguration.Invoke(_params.Parameters, ValueBinder);
+            }
+
+            _invoker(BlockParamsAction);
+        }
+
+        public bool TryGetValue(string param, out object value)
+        {
+            if (_accessors.TryGetValue(param, out var valueProvider))
+            {
+                value = valueProvider();
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+    }
+}

--- a/source/Handlebars/Compiler/Structure/HandlebarsExpression.cs
+++ b/source/Handlebars/Compiler/Structure/HandlebarsExpression.cs
@@ -17,7 +17,8 @@ namespace HandlebarsDotNet.Compiler
         SubExpression = 6009,
         HashParameterAssignmentExpression = 6010,
         HashParametersExpression = 6011,
-        CommentExpression = 6012
+        CommentExpression = 6012,
+        BlockParamsExpression = 6013
     }
 
     internal abstract class HandlebarsExpression : Expression
@@ -35,16 +36,22 @@ namespace HandlebarsDotNet.Compiler
         public static BlockHelperExpression BlockHelper(
             string helperName,
             IEnumerable<Expression> arguments,
+            BlockParamsExpression blockParams,
             Expression body,
             Expression inversion,
             bool isRaw = false)
         {
-            return new BlockHelperExpression(helperName, arguments, body, inversion, isRaw);
+            return new BlockHelperExpression(helperName, arguments, blockParams, body, inversion, isRaw);
         }
 
         public static PathExpression Path(string path)
         {
             return new PathExpression(path);
+        }
+        
+        public static BlockParamsExpression BlockParams(string action, string blockParams)
+        {
+            return new BlockParamsExpression(action, blockParams);
         }
 
         public static StaticExpression Static(string value)
@@ -59,17 +66,19 @@ namespace HandlebarsDotNet.Compiler
 
         public static IteratorExpression Iterator(
             Expression sequence,
+            BlockParamsExpression blockParams,
             Expression template)
         {
-            return new IteratorExpression(sequence, template);
+            return new IteratorExpression(sequence, blockParams, template, Empty());
         }
 
         public static IteratorExpression Iterator(
             Expression sequence,
+            BlockParamsExpression blockParams,
             Expression template,
             Expression ifEmpty)
         {
-            return new IteratorExpression(sequence, template, ifEmpty);
+            return new IteratorExpression(sequence, blockParams, template, ifEmpty);
         }
 
         public static DeferredSectionExpression DeferredSection(

--- a/source/Handlebars/Compiler/Structure/IValueProvider.cs
+++ b/source/Handlebars/Compiler/Structure/IValueProvider.cs
@@ -1,0 +1,8 @@
+namespace HandlebarsDotNet.Compiler
+{
+    internal interface IValueProvider
+    {
+        bool ProvidesNonContextVariables { get; }
+        bool TryGetValue(string memberName, out object value);
+    }
+}

--- a/source/Handlebars/Compiler/Structure/IteratorExpression.cs
+++ b/source/Handlebars/Compiler/Structure/IteratorExpression.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 
 namespace HandlebarsDotNet.Compiler
 {
-    internal class IteratorExpression : HandlebarsExpression
+    internal class IteratorExpression : BlockHelperExpression
     {
         private readonly Expression _sequence;
         private readonly Expression _template;
@@ -16,6 +18,13 @@ namespace HandlebarsDotNet.Compiler
         }
 
         public IteratorExpression(Expression sequence, Expression template, Expression ifEmpty)
+            :this(sequence, BlockParamsExpression.Empty(),  template, ifEmpty)
+        {
+            
+        }
+        
+        public IteratorExpression(Expression sequence, BlockParamsExpression blockParams, Expression template, Expression ifEmpty)
+            :base("each", Enumerable.Empty<Expression>(), blockParams, template, ifEmpty, false)
         {
             _sequence = sequence;
             _template = template;

--- a/source/Handlebars/Compiler/Translation/Expression/BlockHelperFunctionBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/BlockHelperFunctionBinder.cs
@@ -1,4 +1,7 @@
-﻿using System.Linq.Expressions;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace HandlebarsDotNet.Compiler
@@ -38,8 +41,11 @@ namespace HandlebarsDotNet.Compiler
                             Expression.Property(
                                 CompilationContext.BindingContext,
                                 typeof(BindingContext).GetProperty("Value"));
+            
+            var ctor = typeof(BlockParamsValueProvider).GetConstructors().Single();
+            var blockParamsExpression = Expression.New(ctor, CompilationContext.BindingContext, bhex.BlockParams);
 
-            var body = fb.Compile(((BlockExpression)bhex.Body).Expressions, CompilationContext.BindingContext);
+            var body = fb.Compile(((BlockExpression) bhex.Body).Expressions, CompilationContext.BindingContext);
             var inversion = fb.Compile(((BlockExpression)bhex.Inversion).Expressions, CompilationContext.BindingContext);
             var helper = CompilationContext.Configuration.BlockHelpers[bhex.HelperName.Replace("#", "")];
             var arguments = new Expression[]
@@ -50,7 +56,8 @@ namespace HandlebarsDotNet.Compiler
                 Expression.New(
                         typeof(HelperOptions).GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)[0],
                         body,
-                        inversion),
+                        inversion,
+                        blockParamsExpression),
                 //this next arg is usually data, like { first: "Marc" } 
                 //but for inline partials this is the complete BindingContext.
                 bindingContext,

--- a/source/Handlebars/Compiler/Translation/Expression/HandlebarsExpressionVisitor.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/HandlebarsExpressionVisitor.cs
@@ -88,7 +88,7 @@ namespace HandlebarsDotNet.Compiler
 
             if (arguments != bhex.Arguments)
             {
-                return HandlebarsExpression.BlockHelper(bhex.HelperName, arguments, bhex.Body, bhex.Inversion, bhex.IsRaw);
+                return HandlebarsExpression.BlockHelper(bhex.HelperName, arguments, bhex.BlockParams, bhex.Body, bhex.Inversion, bhex.IsRaw);
             }
             return bhex;
         }
@@ -105,7 +105,7 @@ namespace HandlebarsDotNet.Compiler
 
             if (sequence != iex.Sequence)
             {
-                return HandlebarsExpression.Iterator(sequence, iex.Template, iex.IfEmpty);
+                return HandlebarsExpression.Iterator(sequence, iex.BlockParams, iex.Template, iex.IfEmpty);
             }
             return iex;
         }

--- a/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
@@ -47,7 +47,7 @@ namespace HandlebarsDotNet.Compiler
             {
                 bindingContext = Expression.Call(
                     bindingContext,
-                    typeof(BindingContext).GetMethod("CreateChildContext"),
+                    typeof(BindingContext).GetMethod(nameof(BindingContext.CreateChildContext)),
                     pex.Argument ?? Expression.Constant(null),
                     partialBlockTemplate ?? Expression.Constant(null, typeof(Action<TextWriter, object>)));
             }

--- a/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
@@ -166,7 +166,8 @@ namespace HandlebarsDotNet.Compiler
             }
             else
             {
-                resolvedValue = AccessMember(instance, segment);
+                var variable = context.GetVariable(segment);
+                resolvedValue = variable ?? AccessMember(instance, segment);
             }
             return resolvedValue;
         }
@@ -177,6 +178,11 @@ namespace HandlebarsDotNet.Compiler
         {
             if (instance == null)
                 return new UndefinedBindingResult(memberName, CompilationContext.Configuration);
+
+            if (instance is BindingContext context)
+            {
+                return AccessMember(context.Value, memberName);
+            }
             
             var resolvedMemberName = ResolveMemberName(instance, memberName);
             var instanceType = instance.GetType();

--- a/source/Handlebars/Handlebars.csproj
+++ b/source/Handlebars/Handlebars.csproj
@@ -4,7 +4,7 @@
     <DebugType>portable</DebugType>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TargetFrameworks>net452;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <Version>1.10.2</Version>
+    <Version>1.10.3</Version>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
 

--- a/source/Handlebars/HelperOptions.cs
+++ b/source/Handlebars/HelperOptions.cs
@@ -1,30 +1,27 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using HandlebarsDotNet.Compiler;
 
 namespace HandlebarsDotNet
 {
     public sealed class HelperOptions
     {
-        private readonly Action<TextWriter, object> _template;
-        private readonly Action<TextWriter, object> _inverse;
-
         internal HelperOptions(
             Action<TextWriter, object> template,
-            Action<TextWriter, object> inverse)
+            Action<TextWriter, object> inverse,
+            BlockParamsValueProvider blockParamsValueProvider)
         {
-            _template = template;
-            _inverse = inverse;
+            Template = template;
+            Inverse = inverse;
+            BlockParams = blockParamsValueProvider.Configure;
         }
 
-        public Action<TextWriter, object> Template
-        {
-            get { return _template; }
-        }
+        public Action<TextWriter, object> Template { get; }
 
-        public Action<TextWriter, object> Inverse
-        {
-            get { return _inverse; }
-        }
+        public Action<TextWriter, object> Inverse { get; }
+
+        public Action<ConfigureBlockParams> BlockParams { get; }
     }
 }
 


### PR DESCRIPTION
The PR introduces support of BlockParams syntax (#301, mentioned in #294): 
```{{#each enumerateMe as |item id|}}{{@item}}: {{@id}} {{/each}}```
P.S. supports both `@item` and `item` syntax for referring param.

The implementation was guided by emberjs/rfcs/pull/3

Where supported:
- #each:
  - object iterators: first param maps to `@value`, second to `@key`
  - enumerable iterators: first param maps to `@value`, second to `@index`
- #with
- custom helpers via configuring with call to `options.BlockParams(...)`

Notes:
Implementation done in a way to potentially support more keywords then just `as` (in case more would be added in the future) but [strictly limited](https://github.com/rexm/Handlebars.Net/compare/master...zjklee:blockParams-support?expand=1#diff-2b14f2a9d6500f9d13b324ee9b9acd04R31) to support only it for now.

