### PR TITLE
A late-bound helper has priority over variable

### DIFF
--- a/source/Handlebars.Test/ComplexIntegrationTests.cs
+++ b/source/Handlebars.Test/ComplexIntegrationTests.cs
@@ -90,6 +90,36 @@ namespace HandlebarsDotNet.Test
             Assert.Equal("<a href='http://google.com/'>Google</a><a href='http://yahoo.com/'>Yahoo!</a>", result);
         }
 
+        // the helper has priority
+        // https://handlebarsjs.com/guide/expressions.html#disambiguating-helpers-calls-and-property-lookup
+        [Fact]
+        public void HelperWithSameNameVariable()
+        {
+            Handlebars.RegisterHelper("foo", (writer, context, arguments) =>
+            {
+                writer.Write("Helper");
+            });
+
+            var template = Handlebars.Compile("{{foo}}");
+            var result = template(new { foo = "Variable" });
+            Assert.Equal("Helper", result);
+        }
+
+        [Fact]
+        public void LateBoundHelperWithSameNameVariable()
+        {
+            var template = Handlebars.Compile("{{amoeba}}");
+
+            Assert.Equal("Variable", template(new { amoeba = "Variable" }));
+
+            Handlebars.RegisterHelper("amoeba", (writer, context, arguments) =>
+            {
+                writer.Write("Helper");
+            });
+
+            Assert.Equal("Helper", template(new { amoeba = "Variable" }));
+        }
+
         [Fact]
         public void BlockHelperWithSameNameVariable()
         {

--- a/source/Handlebars/Compiler/Translation/Expression/SubExpressionVisitor.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/SubExpressionVisitor.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Linq.Expressions;
 using System.IO;
-using System.Text;
 using System.Reflection;
+using System.Text;
 
 namespace HandlebarsDotNet.Compiler
 {
@@ -25,22 +25,23 @@ namespace HandlebarsDotNet.Compiler
             {
                 throw new HandlebarsCompilerException("Sub-expression does not contain a converted MethodCall expression");
             }
-            HandlebarsHelper helper = GetHelperDelegateFromMethodCallExpression(helperCall);
+            HandlebarsHelperWithName helper = GetHelperDelegateFromMethodCallExpression(helperCall);
             return Expression.Call(
 #if netstandard
-                new Func<HandlebarsHelper, object, object[], string>(CaptureTextWriterOutputFromHelper).GetMethodInfo(),
+                new Func<HandlebarsHelperWithName, dynamic, string, object[], string>(CaptureTextWriterOutputFromHelper).GetMethodInfo(),
 #else
-                new Func<HandlebarsHelper, object, object[], string>(CaptureTextWriterOutputFromHelper).Method,
+                new Func<HandlebarsHelperWithName, dynamic, string, object[], string>(CaptureTextWriterOutputFromHelper).Method,
 #endif
                 Expression.Constant(helper),
                 Visit(helperCall.Arguments[1]),
-                Visit(helperCall.Arguments[2]));
+                Visit(helperCall.Arguments[2]),
+                Visit(helperCall.Arguments[3]));
         }
 
-        private static HandlebarsHelper GetHelperDelegateFromMethodCallExpression(MethodCallExpression helperCall)
+        private static HandlebarsHelperWithName GetHelperDelegateFromMethodCallExpression(MethodCallExpression helperCall)
         {
             object target = helperCall.Object;
-            HandlebarsHelper helper;
+            HandlebarsHelperWithName helper;
             if (target != null)
             {
                 if (target is ConstantExpression)
@@ -52,31 +53,32 @@ namespace HandlebarsDotNet.Compiler
                     throw new NotSupportedException("Helper method instance target must be reduced to a ConstantExpression");
                 }
 #if netstandard
-                helper = (HandlebarsHelper)helperCall.Method.CreateDelegate(typeof(HandlebarsHelper), target);
+                helper = (HandlebarsHelperWithName)helperCall.Method.CreateDelegate(typeof(HandlebarsHelperWithName), target);
 #else
-                helper = (HandlebarsHelper)Delegate.CreateDelegate(typeof(HandlebarsHelper), target, helperCall.Method);
+                helper = (HandlebarsHelperWithName)Delegate.CreateDelegate(typeof(HandlebarsHelperWithName), target, helperCall.Method);
 #endif
             }
             else
             {
 #if netstandard
-                helper = (HandlebarsHelper)helperCall.Method.CreateDelegate(typeof(HandlebarsHelper));
+                helper = (HandlebarsHelperWithName)helperCall.Method.CreateDelegate(typeof(HandlebarsHelperWithName));
 #else
-                helper = (HandlebarsHelper)Delegate.CreateDelegate(typeof(HandlebarsHelper), helperCall.Method);
+                helper = (HandlebarsHelperWithName)Delegate.CreateDelegate(typeof(HandlebarsHelperWithName), helperCall.Method);
 #endif
             }
             return helper;
         }
 
         private static string CaptureTextWriterOutputFromHelper(
-            HandlebarsHelper helper,
-            object context,
+            HandlebarsHelperWithName helper,
+            dynamic context,
+            string name,
             object[] arguments)
         {
             var builder = new StringBuilder();
             using (var writer = new StringWriter(builder))
             {
-                helper(writer, context, arguments);
+                helper(writer, context, name, arguments);
             }
             return builder.ToString();
         }

--- a/source/Handlebars/Handlebars.cs
+++ b/source/Handlebars/Handlebars.cs
@@ -6,6 +6,9 @@ namespace HandlebarsDotNet
     public delegate void HandlebarsHelper(TextWriter output, dynamic context, params object[] arguments);
     public delegate void HandlebarsBlockHelper(TextWriter output, HelperOptions options, dynamic context, params object[] arguments);
 
+    // a HandlebarsHelper that also stores the name of the helper for later use
+    internal delegate void HandlebarsHelperWithName(TextWriter output, dynamic context, string name, params object[] arguments);
+
     public sealed partial class Handlebars
     {
         // Lazy-load Handlebars environment to ensure thread safety.  See Jon Skeet's excellent article on this for more info. http://csharpindepth.com/Articles/General/Singleton.aspx


### PR DESCRIPTION
This has already been the case for late-bound helpers _with arguments_
since they were easily recognised as helper calls. However, helper
resolution was not attempted for simple paths. E.g. for `{{foo}}`, if
"foo" was late-bound, we never attempted to invoke it, we only looked
for "foo" in the data.