### PR TITLE
README.md: Add explicit casting in Handlebars.RegisterHelper

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ var result = template(data);
 
 ```c#
 Handlebars.RegisterHelper("link_to", (writer, context, parameters) => {
-  writer.WriteSafeString("<a href='" + context.url + "'>" + context.text + "</a>");
+    writer.WriteSafeString("<a href='" + (string)context.url + "'>" + (string)context.text + "</a>");
 });
 
 string source = @"Click here: {{link_to}}";

--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ var result = template(data);
 ### Registering Helpers
 
 ```c#
-Handlebars.RegisterHelper("link_to", (writer, context, parameters) => {
-    writer.WriteSafeString("<a href='" + (string)context.url + "'>" + (string)context.text + "</a>");
+Handlebars.RegisterHelper("link_to", (writer, context, parameters) => 
+{
+    writer.WriteSafeString($"<a href='{context["url"]}'>{context["text"]}</a>");
 });
 
 string source = @"Click here: {{link_to}}";

--- a/source/Handlebars.Test/ReadmeTests.cs
+++ b/source/Handlebars.Test/ReadmeTests.cs
@@ -40,5 +40,28 @@ namespace HandlebarsDotNet.Test
                 templateOutput
             );
         }
+        
+        [Fact]
+        public void RegisterHelper()
+        {
+            var source = @"Click here: {{link_to}}";
+            
+            var handlebars = Handlebars.Create();
+            handlebars.RegisterHelper("link_to", (writer, context, parameters) =>
+            {
+                writer.WriteSafeString($"<a href='{context["url"]}'>{context["text"]}</a>");
+            });
+            
+            var template = handlebars.Compile(source);
+
+            var data = new {
+                url = "https://github.com/rexm/handlebars.net",
+                text = "Handlebars.Net"
+            };
+
+            var result = template(data);
+            
+            Assert.Equal($"Click here: <a href='{data.url}'>{data.text}</a>", result);
+        }
     }
 }


### PR DESCRIPTION
Hi,

Thanks for a nice library. Currently trying to learn how it works, by getting some practical experience. :wink: 

One thing I noted is that the example given in `README.md` here doesn't work OOTB. I get errors like this if I try it on my .NET Core 3.1 (on Linux btw):

```
Program.cs(19,17): error CS1973: 'TextWriter' has no applicable method named 'WriteSafeString' but appears to
have an extension method by that name. Extension methods cannot be dynamically dispatched. Consider casting
the dynamic arguments or calling the extension method without the extension method syntax. 
[/home/per/git/halleluja.nu/bin_src/SiteGenerator.ConsoleApp/SiteGenerator.ConsoleApp.csproj]
```

Adding these explicit casts seem to do the trick, so I guess it makes sense to fix this in the example as well.