### PR TITLE
Introduce `HelperOptions` Helper and ReturnHelper

### DIFF
--- a/source/Handlebars/BlockHelperOptions.cs
+++ b/source/Handlebars/BlockHelperOptions.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using HandlebarsDotNet.Collections;
+using HandlebarsDotNet.Compiler;
+using HandlebarsDotNet.Compiler.Structure.Path;
+using HandlebarsDotNet.ValueProviders;
+
+namespace HandlebarsDotNet
+{
+    /// <summary>
+    /// Contains properties accessible withing <see cref="HandlebarsBlockHelper"/> function 
+    /// </summary>
+    public readonly struct BlockHelperOptions
+    {
+        private readonly FixedSizeDictionary<string, object, StringComparer> _extensions;
+        
+        internal readonly TemplateDelegate OriginalTemplate;
+        internal readonly TemplateDelegate OriginalInverse;
+        
+        public readonly BindingContext Frame;
+        
+        public readonly ChainSegment[] BlockVariables;
+
+        internal BlockHelperOptions(
+            TemplateDelegate template,
+            TemplateDelegate inverse,
+            ChainSegment[] blockParamsValues,
+            BindingContext frame
+        )
+        {
+            _extensions = frame.Extensions;
+            
+            OriginalTemplate = template;
+            OriginalInverse = inverse;
+            Frame = frame;
+            BlockVariables = blockParamsValues;
+        }
+        
+        public DataValues Data => new DataValues(Frame);
+        
+        public BlockParamsValues BlockParams => new BlockParamsValues(Frame, BlockVariables);
+        
+        /// <summary>
+        /// BlockHelper body
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Template(in EncodedTextWriter writer, object context)
+        {
+            if (context is BindingContext bindingContext)
+            {
+                OriginalTemplate(writer, bindingContext);
+                return;
+            }
+                
+            using var frame = Frame.CreateFrame(context);
+            OriginalTemplate(writer, frame);
+        }
+        
+        /// <summary>
+        /// BlockHelper body
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Template(in EncodedTextWriter writer, BindingContext context) => OriginalTemplate(writer, context);
+
+        /// <summary>
+        /// BlockHelper body
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Inverse(in EncodedTextWriter writer, object context)
+        {
+            if (context is BindingContext bindingContext)
+            {
+                OriginalInverse(writer, bindingContext);
+                return;
+            }
+                
+            using var frame = Frame.CreateFrame(context);
+            OriginalInverse(writer, frame);
+        }
+        
+        /// <summary>
+        /// BlockHelper body
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Inverse(in EncodedTextWriter writer, BindingContext context) => OriginalInverse(writer, context);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public BindingContext CreateFrame(object value = null) => Frame.CreateFrame(value);
+
+        /// <summary>
+        /// Provides access to dynamic options
+        /// </summary>
+        /// <param name="property"></param>
+        public object this[string property]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _extensions.TryGetValue(property, out var value) ? value : null;
+            
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal set => _extensions.AddOrReplace(property, value, out _);
+        }
+
+        /// <summary>
+        /// Provides access to dynamic data entries in a typed manner
+        /// </summary>
+        /// <param name="property"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public T GetValue<T>(string property) => (T) this[property];
+    }
+}
+

--- a/source/Handlebars/Compiler/Structure/Path/PathInfo.cs
+++ b/source/Handlebars/Compiler/Structure/Path/PathInfo.cs
@@ -112,6 +112,8 @@ namespace HandlebarsDotNet.Compiler.Structure.Path
         /// <inheritdoc cref="ToString"/>
         public static implicit operator string(PathInfo pathInfo) => pathInfo._path;
         
+        public static implicit operator PathInfo(string path) => PathInfoStore.Shared.GetOrAdd(path);
+        
         internal sealed class TrimmedPathEqualityComparer : IEqualityComparer<PathInfo>
         {
             private readonly bool _countParts;

--- a/source/Handlebars/Compiler/Translation/Expression/BlockHelperFunctionBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/BlockHelperFunctionBinder.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using Expressions.Shortcuts;
-using HandlebarsDotNet.Collections;
 using HandlebarsDotNet.Compiler.Structure.Path;
 using HandlebarsDotNet.Helpers.BlockHelpers;
 using HandlebarsDotNet.Polyfills;
@@ -15,13 +10,6 @@ namespace HandlebarsDotNet.Compiler
 {
     internal class BlockHelperFunctionBinder : HandlebarsExpressionVisitor
     {
-        private static readonly LookupSlim<int, DeferredValue<Expression[], ConstructorInfo>> ArgumentsConstructorsMap = new LookupSlim<int, DeferredValue<Expression[], ConstructorInfo>>();
-        private static readonly MethodInfo HelperInvokeMethodInfo = typeof(BlockHelperDescriptorBase).GetMethod(nameof(BlockHelperDescriptorBase.Invoke));
-
-        private static readonly ConstructorInfo HelperOptionsCtor = typeof(HelperOptions)
-            .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
-            .Single(o => o.GetParameters().Length > 0);
-
         private enum BlockHelperDirection { Direct, Inverse }
 
         private CompilationContext CompilationContext { get; }
@@ -103,8 +91,8 @@ namespace HandlebarsDotNet.Compiler
                 
                 var helperOptions = direction switch
                 {
-                    BlockHelperDirection.Direct => New(() => new HelperOptions(direct, inverse, blockParams, bindingContext)),
-                    BlockHelperDirection.Inverse => New(() => new HelperOptions(inverse, direct, blockParams, bindingContext)),
+                    BlockHelperDirection.Direct => New(() => new BlockHelperOptions(direct, inverse, blockParams, bindingContext)),
+                    BlockHelperDirection.Inverse => New(() => new BlockHelperOptions(inverse, direct, blockParams, bindingContext)),
                     _ => throw new HandlebarsCompilerException("Helper referenced with unknown prefix", readerContext)
                 };
                 

--- a/source/Handlebars/Configuration/PathInfoStore.cs
+++ b/source/Handlebars/Configuration/PathInfoStore.cs
@@ -50,7 +50,7 @@ namespace HandlebarsDotNet
             return pathInfo;
         }
         
-        public static PathInfo GetPathInfo(string path)
+        private static PathInfo GetPathInfo(string path)
         {
             if (path == "null")
                 return new PathInfo(false, path, false, null);
@@ -72,18 +72,17 @@ namespace HandlebarsDotNet
             if (pathParts.Length > 1) isValidHelperLiteral = false;
             foreach (var segment in pathParts)
             {
-                if (segment == "..")
+                switch (segment)
                 {
-                    isValidHelperLiteral = false;
-                    segments.Add(new PathSegment(segment, ArrayEx.Empty<ChainSegment>()));
-                    continue;
-                }
-
-                if (segment == ".")
-                {
-                    isValidHelperLiteral = false;
-                    segments.Add(new PathSegment(segment, ArrayEx.Empty<ChainSegment>()));
-                    continue;
+                    case "..":
+                        isValidHelperLiteral = false;
+                        segments.Add(new PathSegment(segment, ArrayEx.Empty<ChainSegment>()));
+                        continue;
+                    
+                    case ".":
+                        isValidHelperLiteral = false;
+                        segments.Add(new PathSegment(segment, ArrayEx.Empty<ChainSegment>()));
+                        continue;
                 }
 
                 var segmentString = isVariable ? "@" + segment : segment;

--- a/source/Handlebars/Features/BuildInHelpersFeature.cs
+++ b/source/Handlebars/Features/BuildInHelpersFeature.cs
@@ -14,10 +14,9 @@ namespace HandlebarsDotNet.Features
     {
         public void OnCompiling(ICompiledHandlebarsConfiguration configuration)
         {
-            var pathInfoStore = configuration.PathInfoStore;
-            configuration.BlockHelpers[pathInfoStore.GetOrAdd("with")] = new StrongBox<BlockHelperDescriptorBase>(new WithBlockHelperDescriptor(configuration));
-            configuration.BlockHelpers[pathInfoStore.GetOrAdd("*inline")] = new StrongBox<BlockHelperDescriptorBase>(new InlineBlockHelperDescriptor(configuration));
-            configuration.Helpers[pathInfoStore.GetOrAdd("lookup")] = new StrongBox<HelperDescriptorBase>(new LookupReturnHelperDescriptor(configuration));
+            configuration.BlockHelpers["with"] = new StrongBox<BlockHelperDescriptorBase>(new WithBlockHelperDescriptor());
+            configuration.BlockHelpers["*inline"] = new StrongBox<BlockHelperDescriptorBase>(new InlineBlockHelperDescriptor());
+            configuration.Helpers["lookup"] = new StrongBox<HelperDescriptorBase>(new LookupReturnHelperDescriptor(configuration));
         }
 
         public void CompilationCompleted()

--- a/source/Handlebars/Handlebars.cs
+++ b/source/Handlebars/Handlebars.cs
@@ -16,11 +16,28 @@ namespace HandlebarsDotNet
     public delegate void HandlebarsHelper(EncodedTextWriter output, object context, Arguments arguments);
     
     /// <summary>
+    /// InlineHelper: {{#helper arg1 arg2}}
+    /// </summary>
+    /// <param name="output"></param>
+    /// <param name="options"></param>
+    /// <param name="context"></param>
+    /// <param name="arguments"></param>
+    public delegate void HandlebarsHelperWithOptions(in EncodedTextWriter output, in HelperOptions options, object context, in Arguments arguments);
+    
+    /// <summary>
     /// InlineHelper: {{#helper arg1 arg2}}, supports <see cref="object"/> value return
     /// </summary>
     /// <param name="context"></param>
     /// <param name="arguments"></param>
     public delegate object HandlebarsReturnHelper(object context, Arguments arguments);
+    
+    /// <summary>
+    /// InlineHelper: {{#helper arg1 arg2}}, supports <see cref="object"/> value return
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="context"></param>
+    /// <param name="arguments"></param>
+    public delegate object HandlebarsReturnWithOptionsHelper(in HelperOptions options, object context, in Arguments arguments);
     
     /// <summary>
     /// BlockHelper: {{#helper}}..{{/helper}}
@@ -29,7 +46,7 @@ namespace HandlebarsDotNet
     /// <param name="options"></param>
     /// <param name="context"></param>
     /// <param name="arguments"></param>
-    public delegate void HandlebarsBlockHelper(EncodedTextWriter output, HelperOptions options, object context, Arguments arguments);
+    public delegate void HandlebarsBlockHelper(EncodedTextWriter output, BlockHelperOptions options, object context, Arguments arguments);
     
     /// <summary>
     /// BlockHelper: {{#helper}}..{{/helper}}
@@ -37,7 +54,7 @@ namespace HandlebarsDotNet
     /// <param name="options"></param>
     /// <param name="context"></param>
     /// <param name="arguments"></param>
-    public delegate object HandlebarsReturnBlockHelper(HelperOptions options, object context, Arguments arguments);
+    public delegate object HandlebarsReturnBlockHelper(BlockHelperOptions options, object context, Arguments arguments);
 
     
     public sealed class Handlebars

--- a/source/Handlebars/HandlebarsEnvironment.cs
+++ b/source/Handlebars/HandlebarsEnvironment.cs
@@ -159,10 +159,20 @@ namespace HandlebarsDotNet
         {
             Configuration.Helpers[helperName] = new DelegateHelperDescriptor(helperName, helperFunction);
         }
+        
+        public void RegisterHelper(string helperName, HandlebarsHelperWithOptions helperFunction)
+        {
+            Configuration.Helpers[helperName] = new DelegateHelperWithOptionsDescriptor(helperName, helperFunction);
+        }
             
         public void RegisterHelper(string helperName, HandlebarsReturnHelper helperFunction)
         {
             Configuration.Helpers[helperName] = new DelegateReturnHelperDescriptor(helperName, helperFunction);
+        }
+        
+        public void RegisterHelper(string helperName, HandlebarsReturnWithOptionsHelper helperFunction)
+        {
+            Configuration.Helpers[helperName] = new DelegateReturnHelperWithOptionsDescriptor(helperName, helperFunction);
         }
 
         public void RegisterHelper(string helperName, HandlebarsBlockHelper helperFunction)

--- a/source/Handlebars/HelperOptions.cs
+++ b/source/Handlebars/HelperOptions.cs
@@ -1,114 +1,16 @@
-﻿using System;
 using System.Runtime.CompilerServices;
-using HandlebarsDotNet.Collections;
 using HandlebarsDotNet.Compiler;
-using HandlebarsDotNet.Compiler.Structure.Path;
+using HandlebarsDotNet.ValueProviders;
 
 namespace HandlebarsDotNet
 {
-    /// <summary>
-    /// Contains properties accessible withing <see cref="HandlebarsBlockHelper"/> function 
-    /// </summary>
     public readonly struct HelperOptions
     {
-        private readonly FixedSizeDictionary<string, object, StringComparer> _extensions;
-        
-        internal readonly TemplateDelegate OriginalTemplate;
-        internal readonly TemplateDelegate OriginalInverse;
-        
         public readonly BindingContext Frame;
         
-        public readonly ChainSegment[] BlockParams;
-
-        internal HelperOptions(
-            TemplateDelegate template,
-            TemplateDelegate inverse,
-            ChainSegment[] blockParamsValues,
-            BindingContext frame
-        )
-        {
-            _extensions = frame.Extensions;
-            
-            OriginalTemplate = template;
-            OriginalInverse = inverse;
-            Frame = frame;
-            BlockParams = blockParamsValues;
-        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public HelperOptions(BindingContext frame) => Frame = frame;
         
-        /// <summary>
-        /// BlockHelper body
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Template(in EncodedTextWriter writer, object context)
-        {
-            if (context is BindingContext bindingContext)
-            {
-                OriginalTemplate(writer, bindingContext);
-                return;
-            }
-                
-            using var frame = Frame.CreateFrame(context);
-            OriginalTemplate(writer, frame);
-        }
-        
-        /// <summary>
-        /// BlockHelper body
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Template(in EncodedTextWriter writer, BindingContext context)
-        {
-            OriginalTemplate(writer, context);
-        }
-        
-        /// <summary>
-        /// BlockHelper body
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Inverse(in EncodedTextWriter writer, object context)
-        {
-            if (context is BindingContext bindingContext)
-            {
-                OriginalInverse(writer, bindingContext);
-                return;
-            }
-                
-            using var frame = Frame.CreateFrame(context);
-            OriginalInverse(writer, frame);
-        }
-        
-        /// <summary>
-        /// BlockHelper body
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Inverse(in EncodedTextWriter writer, BindingContext context)
-        {
-            OriginalInverse(writer, context);
-        }
-        
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public BindingContext CreateFrame(object value = null) => Frame.CreateFrame(value);
-
-        /// <summary>
-        /// Provides access to dynamic options
-        /// </summary>
-        /// <param name="property"></param>
-        public object this[string property]
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _extensions.TryGetValue(property, out var value) ? value : null;
-            
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            internal set => _extensions.AddOrReplace(property, value, out _);
-        }
-
-        /// <summary>
-        /// Provides access to dynamic data entries in a typed manner
-        /// </summary>
-        /// <param name="property"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public T GetValue<T>(string property) => (T) this[property];
+        public DataValues Data => new DataValues(Frame);
     }
 }
-

--- a/source/Handlebars/Helpers/BlockHelpers/BlockHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/BlockHelpers/BlockHelperDescriptor.cs
@@ -1,14 +1,8 @@
-using HandlebarsDotNet.Compiler.Structure.Path;
-
 namespace HandlebarsDotNet.Helpers.BlockHelpers
 {
     public abstract class BlockHelperDescriptor : BlockHelperDescriptorBase
     {
         protected BlockHelperDescriptor(string name) : base(name)
-        {
-        }
-        
-        protected BlockHelperDescriptor(PathInfo name) : base(name)
         {
         }
         

--- a/source/Handlebars/Helpers/BlockHelpers/BlockHelperDescriptorBase.cs
+++ b/source/Handlebars/Helpers/BlockHelpers/BlockHelperDescriptorBase.cs
@@ -1,18 +1,15 @@
-using HandlebarsDotNet.Compiler;
 using HandlebarsDotNet.Compiler.Structure.Path;
 
 namespace HandlebarsDotNet.Helpers.BlockHelpers
 {
     public abstract class BlockHelperDescriptorBase : IHelperDescriptor
     {
-        protected BlockHelperDescriptorBase(string name) => Name = PathInfoStore.Shared.GetOrAdd(name);
-
-        protected BlockHelperDescriptorBase(PathInfo name) => Name = name;
-
+        protected BlockHelperDescriptorBase(string name) => Name = name;
+        
         public PathInfo Name { get; }
         
         public abstract HelperType Type { get; }
         
-        public abstract void Invoke(in EncodedTextWriter output, in HelperOptions options, object context, in Arguments arguments);
+        public abstract void Invoke(in EncodedTextWriter output, in BlockHelperOptions options, object context, in Arguments arguments);
     }
 }

--- a/source/Handlebars/Helpers/BlockHelpers/DelegateBlockHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/BlockHelpers/DelegateBlockHelperDescriptor.cs
@@ -1,20 +1,11 @@
-using HandlebarsDotNet.Compiler.Structure.Path;
-
 namespace HandlebarsDotNet.Helpers.BlockHelpers
 {
     public sealed class DelegateBlockHelperDescriptor : BlockHelperDescriptor
     {
         private readonly HandlebarsBlockHelper _helper;
         
-        public DelegateBlockHelperDescriptor(string name, HandlebarsBlockHelper helper) : base(name) 
-            => _helper = helper;
-        
-        public DelegateBlockHelperDescriptor(PathInfo name, HandlebarsBlockHelper helper) : base(name)
-        {
-            _helper = helper;
-        }
-        
-        public override void Invoke(in EncodedTextWriter output, in HelperOptions options, object context, in Arguments arguments) 
-            => _helper(output, options, context, arguments);
+        public DelegateBlockHelperDescriptor(string name, HandlebarsBlockHelper helper) : base(name) => _helper = helper;
+
+        public override void Invoke(in EncodedTextWriter output, in BlockHelperOptions options, object context, in Arguments arguments) => _helper(output, options, context, arguments);
     }
 }

--- a/source/Handlebars/Helpers/BlockHelpers/DelegateReturnBlockHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/BlockHelpers/DelegateReturnBlockHelperDescriptor.cs
@@ -1,24 +1,11 @@
-using HandlebarsDotNet.Compiler.Structure.Path;
-
 namespace HandlebarsDotNet.Helpers.BlockHelpers
 {
     public sealed class DelegateReturnBlockHelperDescriptor : ReturnBlockHelperDescriptor
     {
         private readonly HandlebarsReturnBlockHelper _helper;
 
-        public DelegateReturnBlockHelperDescriptor(string name, HandlebarsReturnBlockHelper helper) : base(name)
-        {
-            _helper = helper;
-        }
-        
-        public DelegateReturnBlockHelperDescriptor(PathInfo name, HandlebarsReturnBlockHelper helper) : base(name)
-        {
-            _helper = helper;
-        }
+        public DelegateReturnBlockHelperDescriptor(string name, HandlebarsReturnBlockHelper helper) : base(name) => _helper = helper;
 
-        public override object Invoke(in HelperOptions options, object context, in Arguments arguments)
-        {
-            return _helper(options, context, arguments);
-        }
+        protected override object Invoke(in BlockHelperOptions options, object context, in Arguments arguments) => _helper(options, context, arguments);
     }
 }

--- a/source/Handlebars/Helpers/BlockHelpers/InlineBlockHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/BlockHelpers/InlineBlockHelperDescriptor.cs
@@ -4,11 +4,11 @@ namespace HandlebarsDotNet.Helpers.BlockHelpers
 {
     internal sealed class InlineBlockHelperDescriptor : BlockHelperDescriptor
     {
-        public InlineBlockHelperDescriptor(ICompiledHandlebarsConfiguration configuration) : base(configuration.PathInfoStore.GetOrAdd("*inline"))
+        public InlineBlockHelperDescriptor() : base("*inline")
         {
         }
 
-        public override void Invoke(in EncodedTextWriter output, in HelperOptions options, object context, in Arguments arguments)
+        public override void Invoke(in EncodedTextWriter output, in BlockHelperOptions options, object context, in Arguments arguments)
         {
             if (arguments.Length != 1)
             {

--- a/source/Handlebars/Helpers/BlockHelpers/LateBindBlockHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/BlockHelpers/LateBindBlockHelperDescriptor.cs
@@ -1,37 +1,27 @@
 using System.Runtime.CompilerServices;
 using HandlebarsDotNet.Collections;
-using HandlebarsDotNet.Compiler.Structure.Path;
 
 namespace HandlebarsDotNet.Helpers.BlockHelpers
 {
     internal sealed class LateBindBlockHelperDescriptor : BlockHelperDescriptor
     {
-        private readonly ICompiledHandlebarsConfiguration _configuration;
         private readonly StrongBox<BlockHelperDescriptorBase> _blockHelperMissing;
+        private readonly ObservableList<IHelperResolver> _helperResolvers;
 
         public LateBindBlockHelperDescriptor(string name, ICompiledHandlebarsConfiguration configuration) : base(configuration.PathInfoStore.GetOrAdd(name))
         {
-            _configuration = configuration;
-            var pathInfoStore = _configuration.PathInfoStore;
-            _blockHelperMissing = _configuration.BlockHelpers[pathInfoStore.GetOrAdd("blockHelperMissing")];
+            _helperResolvers = (ObservableList<IHelperResolver>) configuration.HelperResolvers;
+            _blockHelperMissing = configuration.BlockHelpers["blockHelperMissing"];
         }
         
-        public LateBindBlockHelperDescriptor(PathInfo name, ICompiledHandlebarsConfiguration configuration) : base(name)
-        {
-            _configuration = configuration;
-            var pathInfoStore = _configuration.PathInfoStore;
-            _blockHelperMissing = _configuration.BlockHelpers[pathInfoStore.GetOrAdd("blockHelperMissing")];
-        }
-        
-        public override void Invoke(in EncodedTextWriter output, in HelperOptions options, object context, in Arguments arguments)
+        public override void Invoke(in EncodedTextWriter output, in BlockHelperOptions options, object context, in Arguments arguments)
         {
             // TODO: add cache
-            var helperResolvers = (ObservableList<IHelperResolver>)_configuration.HelperResolvers;
-            if(helperResolvers.Count != 0)
+            if(_helperResolvers.Count != 0)
             {
-                for (var index = 0; index < helperResolvers.Count; index++)
+                for (var index = 0; index < _helperResolvers.Count; index++)
                 {
-                    if (!helperResolvers[index].TryResolveBlockHelper(Name, out var descriptor)) continue;
+                    if (!_helperResolvers[index].TryResolveBlockHelper(Name, out var descriptor)) continue;
 
                     descriptor.Invoke(output, options, context, arguments);
                     return;

--- a/source/Handlebars/Helpers/BlockHelpers/MissingBlockHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/BlockHelpers/MissingBlockHelperDescriptor.cs
@@ -9,7 +9,7 @@ namespace HandlebarsDotNet.Helpers.BlockHelpers
         {
         }
 
-        public override void Invoke(in EncodedTextWriter output, in HelperOptions options, object context, in Arguments arguments)
+        public override void Invoke(in EncodedTextWriter output, in BlockHelperOptions options, object context, in Arguments arguments)
         {
             var pathInfo = options.GetValue<PathInfo>("path");
             if(arguments.Length > 0) throw new HandlebarsRuntimeException($"Template references a helper that cannot be resolved. BlockHelper '{pathInfo}'");

--- a/source/Handlebars/Helpers/BlockHelpers/ReturnBlockHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/BlockHelpers/ReturnBlockHelperDescriptor.cs
@@ -1,7 +1,3 @@
-using System.IO;
-using HandlebarsDotNet.Compiler;
-using HandlebarsDotNet.Compiler.Structure.Path;
-
 namespace HandlebarsDotNet.Helpers.BlockHelpers
 {
     public abstract class ReturnBlockHelperDescriptor : BlockHelperDescriptorBase
@@ -9,16 +5,12 @@ namespace HandlebarsDotNet.Helpers.BlockHelpers
         protected ReturnBlockHelperDescriptor(string name) : base(name)
         {
         }
-        
-        protected ReturnBlockHelperDescriptor(PathInfo name) : base(name)
-        {
-        }
-        
-        public sealed override HelperType Type { get; } = HelperType.ReturnBlock;
-        
-        public abstract object Invoke(in HelperOptions options, object context, in Arguments arguments);
 
-        public sealed override void Invoke(in EncodedTextWriter output, in HelperOptions options, object context, in Arguments arguments) => 
+        public sealed override HelperType Type { get; } = HelperType.ReturnBlock;
+
+        protected abstract object Invoke(in BlockHelperOptions options, object context, in Arguments arguments);
+
+        public sealed override void Invoke(in EncodedTextWriter output, in BlockHelperOptions options, object context, in Arguments arguments) => 
             output.Write(Invoke(options, context, arguments));
     }
 }

--- a/source/Handlebars/Helpers/BlockHelpers/WithBlockHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/BlockHelpers/WithBlockHelperDescriptor.cs
@@ -4,32 +4,28 @@ namespace HandlebarsDotNet.Helpers.BlockHelpers
 {
     internal sealed class WithBlockHelperDescriptor : BlockHelperDescriptor
     {
-        public WithBlockHelperDescriptor(ICompiledHandlebarsConfiguration configuration) : base(configuration.PathInfoStore.GetOrAdd("with"))
+        public WithBlockHelperDescriptor() : base("with")
         {
         }
 
-        public override void Invoke(in EncodedTextWriter output, in HelperOptions options, object context, in Arguments arguments)
+        public override void Invoke(in EncodedTextWriter output, in BlockHelperOptions options, object context, in Arguments arguments)
         {
             if (arguments.Length != 1)
             {
                 throw new HandlebarsException("{{with}} helper must have exactly one argument");
             }
-            
-            if (HandlebarsUtils.IsTruthyOrNonEmpty(arguments[0]))
-            {
-                using var frame = options.CreateFrame(arguments[0]);
-                var blockParamsValues = new BlockParamsValues(frame, options.BlockParams);
-                
-                blockParamsValues.CreateProperty(0, out var _0);
 
-                blockParamsValues[_0] = arguments[0];
-                
-                options.Template(output, frame);
-            }
-            else
+            if (!HandlebarsUtils.IsTruthyOrNonEmpty(arguments[0]))
             {
                 options.Inverse(output, context);
+                return;
             }
+
+            using var frame = options.CreateFrame(arguments[0]);
+            var blockParamsValues = new BlockParamsValues(frame, options.BlockVariables);
+            blockParamsValues[0] = arguments[0];
+
+            options.Template(output, frame);
         }
     }
 }

--- a/source/Handlebars/Helpers/DelegateHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/DelegateHelperDescriptor.cs
@@ -1,20 +1,11 @@
-using System.IO;
-using HandlebarsDotNet.Compiler;
-using HandlebarsDotNet.Compiler.Structure.Path;
-
 namespace HandlebarsDotNet.Helpers
 {
     public sealed class DelegateHelperDescriptor : HelperDescriptor
     {
         private readonly HandlebarsHelper _helper;
 
-        public DelegateHelperDescriptor(PathInfo name, HandlebarsHelper helper) : base(name) 
-            => _helper = helper;
+        public DelegateHelperDescriptor(string name, HandlebarsHelper helper) : base(name) => _helper = helper;
 
-        public DelegateHelperDescriptor(string name, HandlebarsHelper helper) : base(name) 
-            => _helper = helper;
-
-        public override void Invoke(in EncodedTextWriter output, object context, in Arguments arguments) 
-            => _helper(output, context, arguments);
+        protected override void Invoke(in EncodedTextWriter output, in HelperOptions options, object context, in Arguments arguments) => _helper(output, context, arguments);
     }
 }

--- a/source/Handlebars/Helpers/DelegateHelperWithOptionsDescriptor.cs
+++ b/source/Handlebars/Helpers/DelegateHelperWithOptionsDescriptor.cs
@@ -1,0 +1,11 @@
+namespace HandlebarsDotNet.Helpers
+{
+    public sealed class DelegateHelperWithOptionsDescriptor : HelperDescriptor
+    {
+        private readonly HandlebarsHelperWithOptions _helper;
+
+        public DelegateHelperWithOptionsDescriptor(string name, HandlebarsHelperWithOptions helper) : base(name) => _helper = helper;
+
+        protected override void Invoke(in EncodedTextWriter output, in HelperOptions options, object context, in Arguments arguments) => _helper(output, options, context, arguments);
+    }
+}

--- a/source/Handlebars/Helpers/DelegateReturnHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/DelegateReturnHelperDescriptor.cs
@@ -1,19 +1,11 @@
-using HandlebarsDotNet.Compiler;
-using HandlebarsDotNet.Compiler.Structure.Path;
-
 namespace HandlebarsDotNet.Helpers
 {
     public sealed class DelegateReturnHelperDescriptor : ReturnHelperDescriptor
     {
         private readonly HandlebarsReturnHelper _helper;
 
-        public DelegateReturnHelperDescriptor(PathInfo name, HandlebarsReturnHelper helper) : base(name) 
-            => _helper = helper;
+        public DelegateReturnHelperDescriptor(string name, HandlebarsReturnHelper helper) : base(name) => _helper = helper;
 
-        public DelegateReturnHelperDescriptor(string name, HandlebarsReturnHelper helper) : base(name) 
-            => _helper = helper;
-
-        public override object Invoke(object context, in Arguments arguments) 
-            => _helper(context, arguments);
+        protected override object Invoke(in HelperOptions options, object context, in Arguments arguments) => _helper(context, arguments);
     }
 }

--- a/source/Handlebars/Helpers/DelegateReturnHelperWithOptionsDescriptor.cs
+++ b/source/Handlebars/Helpers/DelegateReturnHelperWithOptionsDescriptor.cs
@@ -1,0 +1,11 @@
+namespace HandlebarsDotNet.Helpers
+{
+    public sealed class DelegateReturnHelperWithOptionsDescriptor : ReturnHelperDescriptor
+    {
+        private readonly HandlebarsReturnWithOptionsHelper _helper;
+
+        public DelegateReturnHelperWithOptionsDescriptor(string name, HandlebarsReturnWithOptionsHelper helper) : base(name) => _helper = helper;
+
+        protected override object Invoke(in HelperOptions options, object context, in Arguments arguments) => _helper(options, context, arguments);
+    }
+}

--- a/source/Handlebars/Helpers/HelperDescriptor.cs
+++ b/source/Handlebars/Helpers/HelperDescriptor.cs
@@ -1,5 +1,4 @@
 using HandlebarsDotNet.Compiler;
-using HandlebarsDotNet.Compiler.Structure.Path;
 
 namespace HandlebarsDotNet.Helpers
 {
@@ -8,14 +7,10 @@ namespace HandlebarsDotNet.Helpers
         protected HelperDescriptor(string name) : base(name)
         {
         }
-        
-        protected HelperDescriptor(PathInfo name) : base(name)
-        {
-        }
 
         public sealed override HelperType Type { get; } = HelperType.Write;
 
-        public abstract void Invoke(in EncodedTextWriter output, object context, in Arguments arguments);
+        protected abstract void Invoke(in EncodedTextWriter output, in HelperOptions options, object context, in Arguments arguments);
 
         internal sealed override object ReturnInvoke(BindingContext bindingContext, object context, in Arguments arguments)
         {
@@ -26,6 +21,10 @@ namespace HandlebarsDotNet.Helpers
             return writer.ToString();
         }
         
-        internal sealed override void WriteInvoke(BindingContext bindingContext, in EncodedTextWriter output, object context, in Arguments arguments) => Invoke(output, context, arguments);
+        internal sealed override void WriteInvoke(BindingContext bindingContext, in EncodedTextWriter output, object context, in Arguments arguments)
+        {
+            var options = new HelperOptions(bindingContext);
+            Invoke(output, options, context, arguments);
+        }
     }
 }

--- a/source/Handlebars/Helpers/HelperDescriptorBase.cs
+++ b/source/Handlebars/Helpers/HelperDescriptorBase.cs
@@ -6,8 +6,6 @@ namespace HandlebarsDotNet.Helpers
     public abstract class HelperDescriptorBase : IHelperDescriptor
     {
         protected HelperDescriptorBase(string name) => Name = PathInfoStore.Shared.GetOrAdd(name);
-        
-        protected HelperDescriptorBase(PathInfo name) => Name = name;
 
         public PathInfo Name { get; }
         public abstract HelperType Type { get; }

--- a/source/Handlebars/Helpers/LookupReturnHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/LookupReturnHelperDescriptor.cs
@@ -6,12 +6,12 @@ namespace HandlebarsDotNet.Helpers
     {
         private readonly ICompiledHandlebarsConfiguration _configuration;
 
-        public LookupReturnHelperDescriptor(ICompiledHandlebarsConfiguration configuration) : base(configuration.PathInfoStore.GetOrAdd("lookup"))
+        public LookupReturnHelperDescriptor(ICompiledHandlebarsConfiguration configuration) : base("lookup")
         {
             _configuration = configuration;
         }
 
-        public override object Invoke(object context, in Arguments arguments)
+        protected override object Invoke(in HelperOptions options, object context, in Arguments arguments)
         {
             if (arguments.Length != 2)
             {

--- a/source/Handlebars/Helpers/MissingHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/MissingHelperDescriptor.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Linq;
-using HandlebarsDotNet.Compiler;
-
 namespace HandlebarsDotNet.Helpers
 {
     internal sealed class MissingHelperDescriptor : ReturnHelperDescriptor
@@ -10,7 +6,7 @@ namespace HandlebarsDotNet.Helpers
         {
         }
 
-        internal override object ReturnInvoke(BindingContext bindingContext, object context, in Arguments arguments)
+        protected override object Invoke(in HelperOptions options, object context, in Arguments arguments)
         {
             var nameArgument = arguments[arguments.Length - 1];
             if (arguments.Length > 1)
@@ -21,7 +17,5 @@ namespace HandlebarsDotNet.Helpers
             var name = PathInfoStore.Shared.GetOrAdd(nameArgument as string ?? nameArgument.ToString());
             return UndefinedBindingResult.Create(name);
         }
-
-        public override object Invoke(object context, in Arguments arguments) => throw new NotSupportedException();
     }
 }

--- a/source/Handlebars/Helpers/ReturnHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/ReturnHelperDescriptor.cs
@@ -1,25 +1,22 @@
-using System.IO;
 using HandlebarsDotNet.Compiler;
-using HandlebarsDotNet.Compiler.Structure.Path;
 
 namespace HandlebarsDotNet.Helpers
 {
     public abstract class ReturnHelperDescriptor : HelperDescriptorBase
     {
-        protected ReturnHelperDescriptor(PathInfo name) : base(name)
-        {
-        }
-        
         protected ReturnHelperDescriptor(string name) : base(name)
         {
         }
         
         public sealed override HelperType Type { get; } = HelperType.Return;
-        
-        public abstract object Invoke(object context, in Arguments arguments);
 
-        internal override object ReturnInvoke(BindingContext bindingContext, object context, in Arguments arguments) => 
-            Invoke(context, arguments);
+        protected abstract object Invoke(in HelperOptions options, object context, in Arguments arguments);
+
+        internal sealed override object ReturnInvoke(BindingContext bindingContext, object context, in Arguments arguments)
+        {
+            var options = new HelperOptions(bindingContext);
+            return Invoke(options, context, arguments);
+        }
 
         internal sealed override void WriteInvoke(BindingContext bindingContext, in EncodedTextWriter output, object context, in Arguments arguments) => 
             output.Write(ReturnInvoke(bindingContext, context, arguments));

--- a/source/Handlebars/IHandlebars.cs
+++ b/source/Handlebars/IHandlebars.cs
@@ -39,8 +39,12 @@ namespace HandlebarsDotNet
         
         void RegisterHelper(string helperName, HandlebarsHelper helperFunction);
         
-        void RegisterHelper(string helperName, HandlebarsReturnHelper helperFunction);
+        void RegisterHelper(string helperName, HandlebarsHelperWithOptions helperFunction);
         
+        void RegisterHelper(string helperName, HandlebarsReturnHelper helperFunction);
+
+        void RegisterHelper(string helperName, HandlebarsReturnWithOptionsHelper helperFunction);
+
         void RegisterHelper(string helperName, HandlebarsBlockHelper helperFunction);
         
         void RegisterHelper(string helperName, HandlebarsReturnBlockHelper helperFunction);

--- a/source/Handlebars/MemberAliasProvider/DelegatedMemberAliasProvider.cs
+++ b/source/Handlebars/MemberAliasProvider/DelegatedMemberAliasProvider.cs
@@ -9,7 +9,7 @@ namespace HandlebarsDotNet
     /// <summary>
     /// Provides simple interface for adding member aliases
     /// </summary>
-    public class DelegatedMemberAliasProvider : IMemberAliasProvider
+    public sealed class DelegatedMemberAliasProvider : IMemberAliasProvider
     {
         private readonly Dictionary<Type, Dictionary<string, Func<object, object>>> _aliases 
             = new Dictionary<Type, Dictionary<string, Func<object, object>>>();

--- a/source/Handlebars/PathInfoLight.cs
+++ b/source/Handlebars/PathInfoLight.cs
@@ -64,6 +64,8 @@ namespace HandlebarsDotNet
         
         public static implicit operator PathInfoLight(PathInfo pathInfo) => new PathInfoLight(pathInfo);
         
+        public static implicit operator PathInfoLight(string path) => new PathInfoLight(PathInfoStore.Shared.GetOrAdd(path));
+        
         public static implicit operator PathInfo(PathInfoLight pathInfo) => pathInfo.PathInfo;
         
         private sealed class EqualityComparer : IEqualityComparer<PathInfoLight>

--- a/source/Handlebars/ValueProviders/BlockParamsValues.cs
+++ b/source/Handlebars/ValueProviders/BlockParamsValues.cs
@@ -9,22 +9,12 @@ namespace HandlebarsDotNet.ValueProviders
     {
         private readonly ChainSegment[] _variables;
         private readonly FixedSizeDictionary<ChainSegment, object, ChainSegment.ChainSegmentEqualityComparer> _values;
-        private readonly ICompiledHandlebarsConfiguration _configuration;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public BlockParamsValues(BindingContext context, ChainSegment[] variables)
         {
             _variables = variables;
-            if (context != null)
-            {
-                _values = context.BlockParamsObject;
-                _configuration = context.Configuration;   
-            }
-            else
-            {
-                _values = null;
-                _configuration = null;
-            }
+            _values = context?.BlockParamsObject;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -48,6 +38,18 @@ namespace HandlebarsDotNet.ValueProviders
             {
                 if(_values == null) return;
                 _values[index] = value;
+            }
+        }
+        
+        public object this[int variableIndex]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set
+            {
+                if(_values == null) return;
+                var variable = GetVariable(variableIndex);
+                if (ReferenceEquals(variable, null)) return;
+                _values.AddOrReplace(variable, value, out _);
             }
         }
 

--- a/source/Handlebars/ValueProviders/DataValues.cs
+++ b/source/Handlebars/ValueProviders/DataValues.cs
@@ -7,23 +7,17 @@ namespace HandlebarsDotNet.ValueProviders
 {
     public readonly ref struct DataValues
     {
-        private readonly BindingContext _context;
         private readonly EntryIndex<ChainSegment>[] _wellKnownVariables;
         private readonly FixedSizeDictionary<ChainSegment, object, ChainSegment.ChainSegmentEqualityComparer> _data;
-        
-        private ICompiledHandlebarsConfiguration Configuration
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _context.Configuration;
-        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public DataValues(BindingContext context)
         {
-            _context = context;
-            _data = _context.ContextDataObject;
+            _data = context.ContextDataObject;
             _wellKnownVariables = context.WellKnownVariables;
         }
+
+        public T Value<T>(ChainSegment segment) => (T) this[segment];
 
         public object this[ChainSegment segment]
         {


### PR DESCRIPTION
What's inside:
- Introduce `HelperOptions` to Helper and ReturnHelper

Breaking changes:
- `HelperOptions` struct in block helpers renamed to `BlockHelperOptions`

Issues:
- closes Handlebars-Net/Handlebars.Net/issues/320