### PR TITLE
Replace `StrongBox<T>` with `Ref<T>`

### DIFF
--- a/source/Handlebars.Test/ClosureBuilderTests.cs
+++ b/source/Handlebars.Test/ClosureBuilderTests.cs
@@ -5,6 +5,7 @@ using HandlebarsDotNet.Compiler;
 using HandlebarsDotNet.Compiler.Structure.Path;
 using HandlebarsDotNet.Helpers;
 using HandlebarsDotNet.Helpers.BlockHelpers;
+using HandlebarsDotNet.Runtime;
 using Xunit;
 
 namespace HandlebarsDotNet.Test
@@ -82,12 +83,12 @@ namespace HandlebarsDotNet.Test
             return others;
         }
         
-        private static List<StrongBox<BlockHelperDescriptorBase>> GenerateBlockHelpers(ClosureBuilder builder, int count)
+        private static List<Ref<BlockHelperDescriptorBase>> GenerateBlockHelpers(ClosureBuilder builder, int count)
         {
-            var blockHelpers = new List<StrongBox<BlockHelperDescriptorBase>>();
+            var blockHelpers = new List<Ref<BlockHelperDescriptorBase>>();
             for (int i = 0; i < count; i++)
             {
-                var blockHelper = new StrongBox<BlockHelperDescriptorBase>();
+                var blockHelper = new Ref<BlockHelperDescriptorBase>();
                 builder.Add(Const(blockHelper));
                 blockHelpers.Add(blockHelper);
             }
@@ -95,12 +96,12 @@ namespace HandlebarsDotNet.Test
             return blockHelpers;
         }
 
-        private static List<StrongBox<HelperDescriptorBase>> GenerateHelpers(ClosureBuilder builder, int count)
+        private static List<Ref<HelperDescriptorBase>> GenerateHelpers(ClosureBuilder builder, int count)
         {
-            var helpers = new List<StrongBox<HelperDescriptorBase>>();
+            var helpers = new List<Ref<HelperDescriptorBase>>();
             for (int i = 0; i < count; i++)
             {
-                var helper = new StrongBox<HelperDescriptorBase>();
+                var helper = new Ref<HelperDescriptorBase>();
                 builder.Add(Const(helper));
                 helpers.Add(helper);
             }

--- a/source/Handlebars/Compiler/ClosureBuilder.cs
+++ b/source/Handlebars/Compiler/ClosureBuilder.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using HandlebarsDotNet.Compiler.Structure.Path;
 using HandlebarsDotNet.Helpers;
 using HandlebarsDotNet.Helpers.BlockHelpers;
+using HandlebarsDotNet.Runtime;
 
 namespace HandlebarsDotNet.Compiler
 {
@@ -15,8 +16,8 @@ namespace HandlebarsDotNet.Compiler
         private readonly List<KeyValuePair<ConstantExpression, PathInfo>> _pathInfos = new List<KeyValuePair<ConstantExpression, PathInfo>>();
         private readonly List<KeyValuePair<ConstantExpression, TemplateDelegate>> _templateDelegates = new List<KeyValuePair<ConstantExpression, TemplateDelegate>>();
         private readonly List<KeyValuePair<ConstantExpression, ChainSegment[]>> _blockParams = new List<KeyValuePair<ConstantExpression, ChainSegment[]>>();
-        private readonly List<KeyValuePair<ConstantExpression, StrongBox<HelperDescriptorBase>>> _helpers = new List<KeyValuePair<ConstantExpression, StrongBox<HelperDescriptorBase>>>();
-        private readonly List<KeyValuePair<ConstantExpression, StrongBox<BlockHelperDescriptorBase>>> _blockHelpers = new List<KeyValuePair<ConstantExpression, StrongBox<BlockHelperDescriptorBase>>>();
+        private readonly List<KeyValuePair<ConstantExpression, Ref<HelperDescriptorBase>>> _helpers = new List<KeyValuePair<ConstantExpression, Ref<HelperDescriptorBase>>>();
+        private readonly List<KeyValuePair<ConstantExpression, Ref<BlockHelperDescriptorBase>>> _blockHelpers = new List<KeyValuePair<ConstantExpression, Ref<BlockHelperDescriptorBase>>>();
         private readonly List<KeyValuePair<ConstantExpression, object>> _other = new List<KeyValuePair<ConstantExpression, object>>();
         
         public void Add(ConstantExpression constantExpression)
@@ -25,13 +26,13 @@ namespace HandlebarsDotNet.Compiler
             {
                 _pathInfos.Add(new KeyValuePair<ConstantExpression, PathInfo>(constantExpression, (PathInfo) constantExpression.Value));
             }
-            else if (constantExpression.Type == typeof(StrongBox<HelperDescriptorBase>))
+            else if (constantExpression.Type == typeof(Ref<HelperDescriptorBase>))
             {
-                _helpers.Add(new KeyValuePair<ConstantExpression, StrongBox<HelperDescriptorBase>>(constantExpression, (StrongBox<HelperDescriptorBase>) constantExpression.Value));
+                _helpers.Add(new KeyValuePair<ConstantExpression, Ref<HelperDescriptorBase>>(constantExpression, (Ref<HelperDescriptorBase>) constantExpression.Value));
             }
-            else if (constantExpression.Type == typeof(StrongBox<BlockHelperDescriptorBase>))
+            else if (constantExpression.Type == typeof(Ref<BlockHelperDescriptorBase>))
             {
-                _blockHelpers.Add(new KeyValuePair<ConstantExpression, StrongBox<BlockHelperDescriptorBase>>(constantExpression, (StrongBox<BlockHelperDescriptorBase>) constantExpression.Value));
+                _blockHelpers.Add(new KeyValuePair<ConstantExpression, Ref<BlockHelperDescriptorBase>>(constantExpression, (Ref<BlockHelperDescriptorBase>) constantExpression.Value));
             }
             else if (constantExpression.Type == typeof(TemplateDelegate))
             {
@@ -126,17 +127,17 @@ namespace HandlebarsDotNet.Compiler
         public readonly PathInfo PI3;
         public readonly PathInfo[] PIA;
         
-        public readonly StrongBox<HelperDescriptorBase> HD0;
-        public readonly StrongBox<HelperDescriptorBase> HD1;
-        public readonly StrongBox<HelperDescriptorBase> HD2;
-        public readonly StrongBox<HelperDescriptorBase> HD3;
-        public readonly StrongBox<HelperDescriptorBase>[] HDA;
+        public readonly Ref<HelperDescriptorBase> HD0;
+        public readonly Ref<HelperDescriptorBase> HD1;
+        public readonly Ref<HelperDescriptorBase> HD2;
+        public readonly Ref<HelperDescriptorBase> HD3;
+        public readonly Ref<HelperDescriptorBase>[] HDA;
         
-        public readonly StrongBox<BlockHelperDescriptorBase> BHD0;
-        public readonly StrongBox<BlockHelperDescriptorBase> BHD1;
-        public readonly StrongBox<BlockHelperDescriptorBase> BHD2;
-        public readonly StrongBox<BlockHelperDescriptorBase> BHD3;
-        public readonly StrongBox<BlockHelperDescriptorBase>[] BHDA;
+        public readonly Ref<BlockHelperDescriptorBase> BHD0;
+        public readonly Ref<BlockHelperDescriptorBase> BHD1;
+        public readonly Ref<BlockHelperDescriptorBase> BHD2;
+        public readonly Ref<BlockHelperDescriptorBase> BHD3;
+        public readonly Ref<BlockHelperDescriptorBase>[] BHDA;
         
         public readonly TemplateDelegate TD0;
         public readonly TemplateDelegate TD1;
@@ -149,7 +150,7 @@ namespace HandlebarsDotNet.Compiler
 
         public readonly object[] A;
 
-        internal Closure(PathInfo pi0, PathInfo pi1, PathInfo pi2, PathInfo pi3, PathInfo[] pia, StrongBox<HelperDescriptorBase> hd0, StrongBox<HelperDescriptorBase> hd1, StrongBox<HelperDescriptorBase> hd2, StrongBox<HelperDescriptorBase> hd3, StrongBox<HelperDescriptorBase>[] hda, StrongBox<BlockHelperDescriptorBase> bhd0, StrongBox<BlockHelperDescriptorBase> bhd1, StrongBox<BlockHelperDescriptorBase> bhd2, StrongBox<BlockHelperDescriptorBase> bhd3, StrongBox<BlockHelperDescriptorBase>[] bhda, TemplateDelegate td0, TemplateDelegate td1, TemplateDelegate td2, TemplateDelegate td3, TemplateDelegate[] tda, ChainSegment[] bp0, ChainSegment[][] bpa, object[] a)
+        internal Closure(PathInfo pi0, PathInfo pi1, PathInfo pi2, PathInfo pi3, PathInfo[] pia, Ref<HelperDescriptorBase> hd0, Ref<HelperDescriptorBase> hd1, Ref<HelperDescriptorBase> hd2, Ref<HelperDescriptorBase> hd3, Ref<HelperDescriptorBase>[] hda, Ref<BlockHelperDescriptorBase> bhd0, Ref<BlockHelperDescriptorBase> bhd1, Ref<BlockHelperDescriptorBase> bhd2, Ref<BlockHelperDescriptorBase> bhd3, Ref<BlockHelperDescriptorBase>[] bhda, TemplateDelegate td0, TemplateDelegate td1, TemplateDelegate td2, TemplateDelegate td3, TemplateDelegate[] tda, ChainSegment[] bp0, ChainSegment[][] bpa, object[] a)
         {
             PI0 = pi0;
             PI1 = pi1;

--- a/source/Handlebars/Compiler/Translation/Expression/BlockHelperFunctionBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/BlockHelperFunctionBinder.cs
@@ -4,6 +4,7 @@ using Expressions.Shortcuts;
 using HandlebarsDotNet.Compiler.Structure.Path;
 using HandlebarsDotNet.Helpers.BlockHelpers;
 using HandlebarsDotNet.Polyfills;
+using HandlebarsDotNet.Runtime;
 using static Expressions.Shortcuts.ExpressionShortcuts;
 
 namespace HandlebarsDotNet.Compiler
@@ -56,14 +57,14 @@ namespace HandlebarsDotNet.Compiler
                 var resolver = helperResolvers[index];
                 if (!resolver.TryResolveBlockHelper(helperName, out var resolvedDescriptor)) continue;
 
-                descriptor = new StrongBox<BlockHelperDescriptorBase>(resolvedDescriptor);
+                descriptor = new Ref<BlockHelperDescriptorBase>(resolvedDescriptor);
                 blockHelpers.Add(pathInfo, descriptor);
                 
                 return BindByRef(descriptor);
             }
             
             var lateBindBlockHelperDescriptor = new LateBindBlockHelperDescriptor(pathInfo, CompilationContext.Configuration);
-            var lateBindBlockHelperRef = new StrongBox<BlockHelperDescriptorBase>(lateBindBlockHelperDescriptor);
+            var lateBindBlockHelperRef = new Ref<BlockHelperDescriptorBase>(lateBindBlockHelperDescriptor);
             blockHelpers.Add(pathInfo, lateBindBlockHelperRef);
 
             return BindByRef(lateBindBlockHelperRef);
@@ -85,7 +86,7 @@ namespace HandlebarsDotNet.Compiler
                 return FunctionBuilder.Compile(blockExpression.Expressions, CompilationContext.Configuration);
             }
 
-            Expression BindByRef(StrongBox<BlockHelperDescriptorBase> helperBox)
+            Expression BindByRef(Ref<BlockHelperDescriptorBase> helperBox)
             {
                 var writer = CompilationContext.Args.EncodedWriter;
                 

--- a/source/Handlebars/Compiler/Translation/Expression/HelperFunctionBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/HelperFunctionBinder.cs
@@ -2,6 +2,7 @@ using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using Expressions.Shortcuts;
 using HandlebarsDotNet.Helpers;
+using HandlebarsDotNet.Runtime;
 using static Expressions.Shortcuts.ExpressionShortcuts;
 
 namespace HandlebarsDotNet.Compiler
@@ -43,13 +44,13 @@ namespace HandlebarsDotNet.Compiler
                 var resolver = configuration.HelperResolvers[index];
                 if (resolver.TryResolveHelper(helperName, typeof(object), out var resolvedHelper))
                 {
-                    helper = new StrongBox<HelperDescriptorBase>(resolvedHelper);
+                    helper = new Ref<HelperDescriptorBase>(resolvedHelper);
                     configuration.Helpers.Add(pathInfo, helper);
                     return Call(() => resolvedHelper.WriteInvoke(bindingContext, textWriter, contextValue, args));
                 }
             }
 
-            var lateBindDescriptor = new StrongBox<HelperDescriptorBase>(new LateBindHelperDescriptor(pathInfo, configuration));
+            var lateBindDescriptor = new Ref<HelperDescriptorBase>(new LateBindHelperDescriptor(pathInfo, configuration));
             configuration.Helpers.Add(pathInfo, lateBindDescriptor);
             
             return Call(() => lateBindDescriptor.Value.WriteInvoke(bindingContext, textWriter, contextValue, args));

--- a/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using Expressions.Shortcuts;
 using HandlebarsDotNet.Compiler.Structure.Path;
 using HandlebarsDotNet.Helpers;
+using HandlebarsDotNet.Runtime;
 using static Expressions.Shortcuts.ExpressionShortcuts;
 
 namespace HandlebarsDotNet.Compiler
@@ -41,7 +42,7 @@ namespace HandlebarsDotNet.Compiler
             var pathInfoLight = new PathInfoLight(pathInfo);
             if (!configuration.Helpers.TryGetValue(pathInfoLight, out var helper))
             {
-                helper = new StrongBox<HelperDescriptorBase>(new LateBindHelperDescriptor(pathInfo, configuration));
+                helper = new  Ref<HelperDescriptorBase>(new LateBindHelperDescriptor(pathInfo, configuration));
                 configuration.Helpers.Add(pathInfoLight, helper);
             }
             else if (configuration.Compatibility.RelaxedHelperNaming)
@@ -49,7 +50,7 @@ namespace HandlebarsDotNet.Compiler
                 pathInfoLight = pathInfoLight.TagComparer();
                 if (!configuration.Helpers.ContainsKey(pathInfoLight))
                 {
-                    helper = new StrongBox<HelperDescriptorBase>(new LateBindHelperDescriptor(pathInfo, configuration));
+                    helper = new  Ref<HelperDescriptorBase>(new LateBindHelperDescriptor(pathInfo, configuration));
                     configuration.Helpers.Add(pathInfoLight, helper);
                 }
             }

--- a/source/Handlebars/Configuration/ICompiledHandlebarsConfiguration.cs
+++ b/source/Handlebars/Configuration/ICompiledHandlebarsConfiguration.cs
@@ -7,6 +7,7 @@ using HandlebarsDotNet.Features;
 using HandlebarsDotNet.Helpers;
 using HandlebarsDotNet.Helpers.BlockHelpers;
 using HandlebarsDotNet.ObjectDescriptors;
+using HandlebarsDotNet.Runtime;
 
 namespace HandlebarsDotNet
 {
@@ -61,12 +62,12 @@ namespace HandlebarsDotNet
         /// <summary>
         /// 
         /// </summary>
-        IDictionary<PathInfoLight, StrongBox<HelperDescriptorBase>> Helpers { get; }
+        IDictionary<PathInfoLight, Ref<HelperDescriptorBase>> Helpers { get; }
         
         /// <summary>
         /// 
         /// </summary>
-        IDictionary<PathInfoLight, StrongBox<BlockHelperDescriptorBase>> BlockHelpers { get; }
+        IDictionary<PathInfoLight, Ref<BlockHelperDescriptorBase>> BlockHelpers { get; }
         
         /// <summary>
         /// 

--- a/source/Handlebars/Features/BuildInHelpersFeature.cs
+++ b/source/Handlebars/Features/BuildInHelpersFeature.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using HandlebarsDotNet.Helpers;
 using HandlebarsDotNet.Helpers.BlockHelpers;
+using HandlebarsDotNet.Runtime;
 
 namespace HandlebarsDotNet.Features
 {
@@ -14,9 +15,9 @@ namespace HandlebarsDotNet.Features
     {
         public void OnCompiling(ICompiledHandlebarsConfiguration configuration)
         {
-            configuration.BlockHelpers["with"] = new StrongBox<BlockHelperDescriptorBase>(new WithBlockHelperDescriptor());
-            configuration.BlockHelpers["*inline"] = new StrongBox<BlockHelperDescriptorBase>(new InlineBlockHelperDescriptor());
-            configuration.Helpers["lookup"] = new StrongBox<HelperDescriptorBase>(new LookupReturnHelperDescriptor(configuration));
+            configuration.BlockHelpers["with"] = new Ref<BlockHelperDescriptorBase>(new WithBlockHelperDescriptor());
+            configuration.BlockHelpers["*inline"] = new Ref<BlockHelperDescriptorBase>(new InlineBlockHelperDescriptor());
+            configuration.Helpers["lookup"] = new Ref<HelperDescriptorBase>(new LookupReturnHelperDescriptor(configuration));
         }
 
         public void CompilationCompleted()

--- a/source/Handlebars/Features/MissingHelperFeature.cs
+++ b/source/Handlebars/Features/MissingHelperFeature.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using HandlebarsDotNet.Helpers;
 using HandlebarsDotNet.Helpers.BlockHelpers;
+using HandlebarsDotNet.Runtime;
 
 namespace HandlebarsDotNet.Features
 {
@@ -97,7 +98,7 @@ namespace HandlebarsDotNet.Features
             {
                 var helper = _helper ?? new MissingHelperDescriptor();
                 configuration.Helpers.AddOrUpdate(helperMissingPathInfo, 
-                    h => new StrongBox<HelperDescriptorBase>(h), 
+                    h => new Ref<HelperDescriptorBase>(h), 
                     (h, o) => o.Value = h, 
                     helper);
             }
@@ -107,7 +108,7 @@ namespace HandlebarsDotNet.Features
             {
                 var blockHelper = _blockHelper ?? new MissingBlockHelperDescriptor();
                 configuration.BlockHelpers.AddOrUpdate(blockHelperMissingKeyPathInfo, 
-                    h => new StrongBox<BlockHelperDescriptorBase>(h), 
+                    h => new Ref<BlockHelperDescriptorBase>(h), 
                     (h, o) => o.Value = h, 
                     blockHelper);
             }

--- a/source/Handlebars/Helpers/BlockHelpers/LateBindBlockHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/BlockHelpers/LateBindBlockHelperDescriptor.cs
@@ -1,11 +1,12 @@
 using System.Runtime.CompilerServices;
 using HandlebarsDotNet.Collections;
+using HandlebarsDotNet.Runtime;
 
 namespace HandlebarsDotNet.Helpers.BlockHelpers
 {
     internal sealed class LateBindBlockHelperDescriptor : BlockHelperDescriptor
     {
-        private readonly StrongBox<BlockHelperDescriptorBase> _blockHelperMissing;
+        private readonly  Ref<BlockHelperDescriptorBase> _blockHelperMissing;
         private readonly ObservableList<IHelperResolver> _helperResolvers;
 
         public LateBindBlockHelperDescriptor(string name, ICompiledHandlebarsConfiguration configuration) : base(configuration.PathInfoStore.GetOrAdd(name))

--- a/source/Handlebars/Helpers/LateBindHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/LateBindHelperDescriptor.cs
@@ -1,12 +1,13 @@
 using System.Runtime.CompilerServices;
 using HandlebarsDotNet.Collections;
 using HandlebarsDotNet.Compiler.Structure.Path;
+using HandlebarsDotNet.Runtime;
 
 namespace HandlebarsDotNet.Helpers
 {
     internal sealed class LateBindHelperDescriptor : ReturnHelperDescriptor
     {
-        private readonly StrongBox<HelperDescriptorBase> _helperMissing;
+        private readonly Ref<HelperDescriptorBase> _helperMissing;
         private readonly ObservableList<IHelperResolver> _helperResolvers;
 
         public LateBindHelperDescriptor(string name, ICompiledHandlebarsConfiguration configuration) : base(name)

--- a/source/Handlebars/Runtime/Ref.cs
+++ b/source/Handlebars/Runtime/Ref.cs
@@ -1,0 +1,31 @@
+using System.Runtime.CompilerServices;
+
+namespace HandlebarsDotNet.Runtime
+{
+    public class Ref<T> where T: class
+    {
+        private readonly Ref<T> _parent;
+        private T _value;
+
+        public T Value
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _value ?? _parent?.Value;
+            
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set => _value = value;
+        }
+
+        public Ref() { }
+        
+        public Ref(T value) => _value = value;
+
+        public Ref(Ref<T> parent) => _parent = parent;
+
+        public Ref(T value, Ref<T> parent)
+        {
+            _value = value;
+            _parent = parent;
+        }
+    }
+}


### PR DESCRIPTION
Replace `StrongBox<T>` with `Ref<T>` to enable future support of `decorators`