### PR TITLE
Multiple fixes to path resolvement

### DIFF
--- a/source/Handlebars.Test/BasicIntegrationTests.cs
+++ b/source/Handlebars.Test/BasicIntegrationTests.cs
@@ -359,6 +359,58 @@ false
         }
 
         [Theory, ClassData(typeof(HandlebarsEnvGenerator))]
+        public void PathRelativeBinding(IHandlebars handlebars)
+        {
+            var template =
+                @"{{#each users}}
+                    {{this/person.name/firstName}}
+                    {{#with this/person.name}}
+                        {{lastName}}
+                        {{lookup (lookup ../this/../users @index) 'twitter'}}
+                    {{/with}}
+                {{/each}}";
+
+            var handlebarsTemplate = handlebars.Compile(template);
+
+            var data = new
+            {
+                users = new object[]
+                {
+                    new
+                    {
+                        person = new
+                        {
+                            name = new
+                            {
+                                firstName = "Garry",
+                                lastName = "Finch"
+                            }
+                        },
+                        jobTitle = "Front End Technical Lead",
+                        twitter = "gazraa"
+                    },
+                    new
+                    {
+                        person = new
+                        {
+                            name = new
+                            {
+                                firstName = "Karen",
+                                lastName = "Finch"
+                            }
+                        },
+                        jobTitle = "Photographer",
+                        twitter = "photobasics"
+                    }
+                }
+            };
+
+            var result = handlebarsTemplate(data);
+            var actual = string.Join(" ", result.Split(new []{"\r\n"}, StringSplitOptions.RemoveEmptyEntries).Select(o => o.Trim(' ')));
+            Assert.Equal("Garry Finch gazraa Karen Finch photobasics", actual);
+        }
+
+        [Theory, ClassData(typeof(HandlebarsEnvGenerator))]
         public void BasicPropertyOnArray(IHandlebars handlebars)
         {
             var source = "Array is {{ names.Length }} item(s) long";

--- a/source/Handlebars.Test/IssueTests.cs
+++ b/source/Handlebars.Test/IssueTests.cs
@@ -1,6 +1,10 @@
 using System;
 using System.Dynamic;
 using System.IO;
+using HandlebarsDotNet.Collections;
+using HandlebarsDotNet.Helpers;
+using HandlebarsDotNet.PathStructure;
+using HandlebarsDotNet.StringUtils;
 using Xunit;
 
 namespace HandlebarsDotNet.Test
@@ -219,6 +223,95 @@ namespace HandlebarsDotNet.Test
             var result = compiled(null);
 
             Assert.Equal("hello world", result);
+        }
+        
+        
+        // issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/399
+        [Fact]
+        public void PassesWhenMemberAccessorIsNull()
+        {
+            var template = "{{Join ['a', \"b \",  42] ':'}}";
+
+            var handlebars = Handlebars.Create();
+            handlebars.RegisterHelper(new JoinHelper());
+
+            var handlebarsTemplate = handlebars.Compile(template);
+            var actual = handlebarsTemplate("");
+            
+            Assert.Equal("a:b :42", actual);
+        }
+
+        // issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/402
+        [Fact]
+        public void NestedObjectIteration()
+        {
+            const string template = @"
+                {{#with test}}
+
+					{{#if complexItems}}
+					<ul>
+						{{#each complexItems}}
+							<li>{{name}} {{value}} {{evenMoreComplex.name}} {{evenMoreComplex.abbr}}</li>
+						{{/each}}
+					</ul>
+					{{/if}}
+
+				{{/with}}";
+            
+            var data = new
+            {
+                test = new
+                {
+                    complexItems = new[] {
+                        new { name = "a", value = 1, evenMoreComplex = new { name = "zzz", abbr = "z" } },
+                        new { name = "b", value = 2, evenMoreComplex = new { name = "yyy", abbr = "y" } },
+                        new { name = "c", value = 3, evenMoreComplex = new { name = "xxx", abbr = "x" } }
+                    },
+                }
+            };
+
+            var handlebars = Handlebars.Create();
+            var handlebarsTemplate = handlebars.Compile(template);
+
+            var result = handlebarsTemplate(data);
+            
+            const string expected = "<ul><li>a 1 zzz z</li><li>b 2 yyy y</li><li>c 3 xxx x</li></ul>";
+            var actual = result.Replace("\n", string.Empty).Replace("\t", string.Empty);
+            
+            Assert.Equal(expected, actual);
+        }
+        
+        private class JoinHelper : IHelperDescriptor<HelperOptions>
+        {
+            public PathInfo Name { get; } = "join";
+            
+            public object Invoke(in HelperOptions options, in Context context, in Arguments arguments)
+            {
+                return this.ReturnInvoke(options, context, arguments);
+            }
+
+            public void Invoke(in EncodedTextWriter output, in HelperOptions options, in Context context, in Arguments arguments)
+            {
+                var undefinedBindingResult = arguments.At<UndefinedBindingResult>(0);
+                var separator = arguments.At<string>(1);
+                var values = Substring.TrimStart(undefinedBindingResult.Value, '[');
+                values = Substring.TrimEnd(values, ']');
+                var substrings = Substring.Split(values, ',');
+                var extendedEnumerator = ExtendedEnumerator<Substring>.Create(substrings);
+                
+                while (extendedEnumerator.MoveNext())
+                {
+                    var substring = extendedEnumerator.Current.Value;
+                    substring = Substring.Trim(substring, ' ');
+                    substring = Substring.Trim(substring, '"');
+                    substring = Substring.Trim(substring, '\'');
+                    output.Write(substring);
+                    if (!extendedEnumerator.Current.IsLast)
+                    {
+                        output.Write(separator);
+                    }
+                }
+            }
         }
     }
 }

--- a/source/Handlebars.Test/IssueTests.cs
+++ b/source/Handlebars.Test/IssueTests.cs
@@ -276,7 +276,10 @@ namespace HandlebarsDotNet.Test
             var result = handlebarsTemplate(data);
             
             const string expected = "<ul><li>a 1 zzz z</li><li>b 2 yyy y</li><li>c 3 xxx x</li></ul>";
-            var actual = result.Replace("\n", string.Empty).Replace("\t", string.Empty);
+            var actual = result
+                .Replace("\n", string.Empty)
+                .Replace("\r", string.Empty)
+                .Replace("\t", string.Empty);
             
             Assert.Equal(expected, actual);
         }

--- a/source/Handlebars.Test/PathInfoTests.cs
+++ b/source/Handlebars.Test/PathInfoTests.cs
@@ -1,0 +1,64 @@
+using System.Linq;
+using HandlebarsDotNet.PathStructure;
+using Xunit;
+
+namespace HandlebarsDotNet.Test
+{
+    public class PathInfoTests
+    {
+        [Theory]
+        [InlineData("abc")]
+        [InlineData("ab1c")]
+        [InlineData("a")]
+        public void SimplePath(string input)
+        {
+            var pathInfo = PathInfo.Parse(input);
+            
+            Assert.Equal(input, pathInfo.Path);
+            Assert.Equal(input.Trim('[', ']'), pathInfo.TrimmedPath);
+            Assert.False(pathInfo.IsVariable);
+            var chainSegment = Assert.Single(pathInfo.Segments.SelectMany(o => o.PathChain));
+            Assert.NotNull(chainSegment);
+            Assert.Equal(input, chainSegment.ToString());
+        }
+        
+        [Fact]
+        public void DotPath()
+        {
+            var input = "a.b.1.c";
+            
+            var pathInfo = PathInfo.Parse(input);
+            
+            Assert.Equal(input, pathInfo.Path);
+
+            var parts = input.Split('.');
+            var pathChain = pathInfo.Segments.SelectMany(o => o.PathChain).ToArray();
+            for (var index = 0; index < pathChain.Length; index++)
+            {
+                Assert.Equal(parts[index], pathChain[index]);
+            }
+        }
+        
+        [Theory]
+        [InlineData("a")]
+        [InlineData("a.c")]
+        [InlineData("a//c")]
+        [InlineData("a/b/c")]
+        [InlineData("a/b.c/d")]
+        [InlineData("a/[b.c]/d")]
+        [InlineData("a/[b/c]/d")]
+        [InlineData("a/[b.c/d]/e")]
+        public void SlashPath(string input)
+        {
+            var pathInfo = PathInfo.Parse(input);
+            
+            Assert.Equal(input, pathInfo.Path);
+
+            var parts = input.Split('/');
+            for (var index = 0; index < pathInfo.Segments.Length; index++)
+            {
+                Assert.Equal(parts[index], pathInfo.Segments[index].ToString());
+            }
+        }
+    }
+}

--- a/source/Handlebars.Test/SubstringTests.cs
+++ b/source/Handlebars.Test/SubstringTests.cs
@@ -34,9 +34,10 @@ namespace HandlebarsDotNet.Test
             var substring = new Substring(input);
             var split = Substring.Split(substring, splitChar);
 
-            for (var index = 0; index < expected.Length; index++)
+            var index = 0;
+            while (split.MoveNext())
             {
-                Assert.True(split[index] == expected[index]);
+                Assert.Equal(split.Current, expected[index++]);
             }
         }
         

--- a/source/Handlebars/Collections/EnumeratorValue.cs
+++ b/source/Handlebars/Collections/EnumeratorValue.cs
@@ -1,7 +1,10 @@
+using System.Runtime.CompilerServices;
+
 namespace HandlebarsDotNet.Collections
 {
     public readonly ref struct EnumeratorValue<T>
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public EnumeratorValue(T value, int index, bool isLast)
         {
             Value = value;

--- a/source/Handlebars/Collections/ExtendedEnumerator.cs
+++ b/source/Handlebars/Collections/ExtendedEnumerator.cs
@@ -6,6 +6,16 @@ namespace HandlebarsDotNet.Collections
 {
     public ref struct ExtendedEnumerator<T>
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ExtendedEnumerator<T> Create(IEnumerator enumerator) 
+            => new ExtendedEnumerator<T>(enumerator);
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ExtendedEnumerator<T, TEnumerator> Create<TEnumerator>(TEnumerator enumerator) 
+            where TEnumerator: IEnumerator<T>
+            => new ExtendedEnumerator<T, TEnumerator>(enumerator);
+        
+        
         private readonly IEnumerator _enumerator;
 
         private T _next;
@@ -17,8 +27,12 @@ namespace HandlebarsDotNet.Collections
         {
             _enumerator = enumerator;
             PerformIteration();
+
+            Any = _hasNext;
         }
-            
+
+        public readonly bool Any;
+        
         public EnumeratorValue<T> Current { get; private set; }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -70,8 +84,12 @@ namespace HandlebarsDotNet.Collections
         {
             _enumerator = enumerator;
             PerformIteration();
+
+            Any = _hasNext;
         }
-            
+
+        public readonly bool Any;
+
         public EnumeratorValue<T> Current { get; private set; }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/source/Handlebars/Collections/FixedSizeDictionary.cs
+++ b/source/Handlebars/Collections/FixedSizeDictionary.cs
@@ -369,6 +369,16 @@ namespace HandlebarsDotNet.Collections
             destination._count = _count;
         }
 
+        public void AdjustIndexes(EntryIndex<TKey>[] source, FixedSizeDictionary<TKey, TValue, TComparer> destination, EntryIndex<TKey>[] target)
+        {
+            if(source.Length != target.Length) Throw.CapacityShouldBeEqual(nameof(target));
+            
+            for (var i = 0; i < source.Length; i++)
+            {
+                target[i] = new EntryIndex<TKey>(source[i].Index, destination._version);
+            }
+        }
+
         /// <summary>
         /// Performs fast cleanup without cleaning internal storage (does not make objects available for GC)
         /// </summary>

--- a/source/Handlebars/EqualityComparers/PathInfo.TrimmedPathEqualityComparer.cs
+++ b/source/Handlebars/EqualityComparers/PathInfo.TrimmedPathEqualityComparer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace HandlebarsDotNet.PathStructure
@@ -7,10 +8,14 @@ namespace HandlebarsDotNet.PathStructure
         internal readonly struct TrimmedPathEqualityComparer : IEqualityComparer<PathInfo>
         {
             private readonly bool _countParts;
+            private readonly bool _ignoreCase;
+            private readonly StringComparison _stringComparison;
 
-            public TrimmedPathEqualityComparer(bool countParts = true)
+            public TrimmedPathEqualityComparer(bool countParts = true, bool ignoreCase = true)
             {
+                _ignoreCase = ignoreCase;
                 _countParts = countParts;
+                _stringComparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
             }
             
             public bool Equals(PathInfo x, PathInfo y)
@@ -19,12 +24,13 @@ namespace HandlebarsDotNet.PathStructure
                 if (ReferenceEquals(x, null)) return false;
                 if (ReferenceEquals(y, null)) return false;
                 
-                return (!_countParts || x.PathChain.Length == y.PathChain.Length) && string.Equals(x.TrimmedPath, y.TrimmedPath);
+                return (!_countParts || x.Segments.Length == y.Segments.Length) 
+                       && string.Equals(x.TrimmedPath, y.TrimmedPath, _stringComparison);
             }
 
             public int GetHashCode(PathInfo obj)
             {
-                return obj._trimmedHashCode;
+                return _ignoreCase ? obj._trimmedInvariantHashCode : obj._trimmedHashCode;
             }
         }
     }

--- a/source/Handlebars/EqualityComparers/PathInfoLight.PathInfoLightEqualityComparer.cs
+++ b/source/Handlebars/EqualityComparers/PathInfoLight.PathInfoLightEqualityComparer.cs
@@ -9,9 +9,9 @@ namespace HandlebarsDotNet
         {
             private readonly PathInfo.TrimmedPathEqualityComparer _comparer;
 
-            public PathInfoLightEqualityComparer(bool countParts = true)
+            public PathInfoLightEqualityComparer(bool countParts = true, bool ignoreCase = true)
             {
-                _comparer = new PathInfo.TrimmedPathEqualityComparer(countParts);
+                _comparer = new PathInfo.TrimmedPathEqualityComparer(countParts, ignoreCase);
             }
             
             public bool Equals(PathInfoLight x, PathInfoLight y)

--- a/source/Handlebars/Helpers/LookupReturnHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/LookupReturnHelperDescriptor.cs
@@ -14,9 +14,7 @@ namespace HandlebarsDotNet.Helpers
             }
             
             var segment = ChainSegment.Create(arguments[1]);
-
-            var configuration = options.Frame.Configuration;
-            return !PathResolver.TryAccessMember(arguments[0], segment, configuration, out var value) 
+            return !options.TryAccessMember(arguments[0], segment, out var value)
                 ? UndefinedBindingResult.Create(segment)
                 : value;
         }

--- a/source/Handlebars/IHelperOptions.cs
+++ b/source/Handlebars/IHelperOptions.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using HandlebarsDotNet.PathStructure;
 using HandlebarsDotNet.ValueProviders;
 
@@ -8,5 +9,22 @@ namespace HandlebarsDotNet
         BindingContext Frame { get; }
         DataValues Data { get; }
         PathInfo Name { get; }
+    }
+
+    public static class HelperOptionsExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryAccessMember<T>(this T helperOptions, object instance, ChainSegment chainSegment, out object value)
+            where T: IHelperOptions
+        {
+            return PathResolver.TryAccessMember(helperOptions.Frame, instance, chainSegment, out value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static object ResolvePath<T>(this T helperOptions, PathInfo pathInfo)
+            where T: IHelperOptions
+        {
+            return PathResolver.ResolvePath(helperOptions.Frame, pathInfo);
+        }
     }
 }

--- a/source/Handlebars/IO/EncodedTextWriter.cs
+++ b/source/Handlebars/IO/EncodedTextWriter.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using HandlebarsDotNet.IO;
+using HandlebarsDotNet.StringUtils;
 
 namespace HandlebarsDotNet
 {
@@ -71,6 +72,21 @@ namespace HandlebarsDotNet
 		}
 		
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public void Write(Substring value, bool encode = true)
+		{
+			if(encode && !SuppressEncoding)
+			{
+				_encoder.Encode(value.GetEnumerator(), UnderlyingWriter);
+				return;
+			}
+
+			for (int i = 0; i < value.Length; i++)
+			{
+				UnderlyingWriter.Write(value[i]);
+			}
+		}
+		
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public void Write<T>(T value, bool encode) where T: IEnumerator<char>
 		{
 			if(encode && !SuppressEncoding)
@@ -105,10 +121,12 @@ namespace HandlebarsDotNet
 				case null:
 				case string v when string.IsNullOrEmpty(v): 
 				case StringBuilder st when st.Length == 0:
+				case Substring substring when substring.Length == 0:
 					return;
 				
 				case string v: Write(v, true); return;
 				case StringBuilder v: Write(v, true); return;
+				case Substring v: Write(v, true); return; 
 				
 				default:
 					WriteFormatted(value);

--- a/source/Handlebars/Iterators/DynamicObjectIterator.cs
+++ b/source/Handlebars/Iterators/DynamicObjectIterator.cs
@@ -35,7 +35,7 @@ namespace HandlebarsDotNet.Iterators
             blockParamsValues.CreateProperty(1, out var _1);
             
             var properties = _descriptor.GetProperties(_descriptor, input).Cast<ChainSegment>();
-            var enumerator = new ExtendedEnumerator<ChainSegment, IEnumerator<ChainSegment>>(properties.GetEnumerator());
+            var enumerator = ExtendedEnumerator<ChainSegment>.Create(properties.GetEnumerator());
 
             iterator.First = BoxedValues.True;
             iterator.Last = BoxedValues.False;

--- a/source/Handlebars/Iterators/EnumerableIterator'2.cs
+++ b/source/Handlebars/Iterators/EnumerableIterator'2.cs
@@ -28,7 +28,7 @@ namespace HandlebarsDotNet.Iterators
 
             var target = (T) input;
             var outerEnumerator = target.GetEnumerator();
-            var enumerator = new ExtendedEnumerator<TValue, IEnumerator<TValue>>(outerEnumerator);
+            var enumerator = ExtendedEnumerator<TValue>.Create(outerEnumerator);
 
             iterator.First = BoxedValues.True;
             iterator.Last = BoxedValues.False;

--- a/source/Handlebars/Iterators/EnumerableIterator.cs
+++ b/source/Handlebars/Iterators/EnumerableIterator.cs
@@ -27,7 +27,7 @@ namespace HandlebarsDotNet.Iterators
             blockParamsValues.CreateProperty(1, out var _1);
 
             var target = (T) input;
-            var enumerator = new ExtendedEnumerator<object>(target.GetEnumerator());
+            var enumerator = ExtendedEnumerator<object>.Create(target.GetEnumerator());
 
             iterator.First = BoxedValues.True;
             iterator.Last = BoxedValues.False;

--- a/source/Handlebars/ObjectDescriptors/ObjectAccessor.cs
+++ b/source/Handlebars/ObjectDescriptors/ObjectAccessor.cs
@@ -47,7 +47,15 @@ namespace HandlebarsDotNet
                 : null;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool TryGetValue(ChainSegment segment, out object value) => 
-            _memberAccessor.TryGetValue(_data, segment, out value);
+        public bool TryGetValue(ChainSegment segment, out object value)
+        {
+            if (_memberAccessor == null)
+            {
+                value = null;
+                return false;
+            }
+            
+            return _memberAccessor.TryGetValue(_data, segment, out value);
+        }
     }
 }

--- a/source/Handlebars/PathStructure/PathResolver.cs
+++ b/source/Handlebars/PathStructure/PathResolver.cs
@@ -59,32 +59,6 @@ namespace HandlebarsDotNet.PathStructure
             return instance;
         }
 
-        private static object ResolveValue(bool isVariable, BindingContext context, object instance, ChainSegment chainSegment)
-        {
-            object resolvedValue;
-            if (isVariable)
-            {
-                return context.TryGetContextVariable(chainSegment, out resolvedValue)
-                    ? resolvedValue
-                    : UndefinedBindingResult.Create(chainSegment);
-            }
-
-            if (chainSegment.IsThis) return instance;
-
-            if (context.TryGetVariable(chainSegment, out resolvedValue)
-                || TryAccessMember(context, instance, chainSegment, out resolvedValue))
-            {
-                return resolvedValue;
-            }
-            
-            if (chainSegment.IsValue && context.TryGetContextVariable(chainSegment, out resolvedValue))
-            {
-                return resolvedValue;
-            }
-
-            return UndefinedBindingResult.Create(chainSegment);
-        }
-        
         private static bool TryResolveValue(bool isVariable, BindingContext context, ChainSegment chainSegment, object instance, out object value)
         {
             if (isVariable)

--- a/source/Handlebars/PathStructure/PathSegment.cs
+++ b/source/Handlebars/PathStructure/PathSegment.cs
@@ -1,3 +1,4 @@
+using System;
 using HandlebarsDotNet.StringUtils;
 
 namespace HandlebarsDotNet.PathStructure
@@ -5,22 +6,79 @@ namespace HandlebarsDotNet.PathStructure
     /// <summary>
     /// Represents parts of single <see cref="PathInfo"/> separated with '/'.
     /// </summary>
-    public readonly struct PathSegment
+    public readonly struct PathSegment : IEquatable<PathSegment>, IEquatable<string>
     {
-        internal readonly bool IsContextChange;
+        private static readonly Substring ThisSubstring = "this";
+        
+        private readonly int _hashCode;
+        
+        internal readonly bool IsParent;
         internal readonly bool IsThis;
         
-        internal PathSegment(Substring segment, ChainSegment[] chain)
+        internal PathSegment(Substring segment, ChainSegment[] chain) : this()
         {
             IsNotEmpty = segment.Length != 0;
-            IsContextChange = IsNotEmpty && segment == "..";
-            IsThis = IsNotEmpty && !IsContextChange && segment == ".";
+            IsParent = IsNotEmpty && segment == "..";
+            IsThis = IsNotEmpty && !IsParent && (segment == "." || Substring.EqualsIgnoreCase(segment, ThisSubstring));
             PathChain = chain;
+
+            _hashCode = GetHashCodeImpl();
         }
         
         /// <inheritdoc cref="ChainSegment"/>
         public readonly ChainSegment[] PathChain;
 
         public readonly bool IsNotEmpty;
+
+        public bool Equals(PathSegment other)
+        {
+            bool basicEquals = IsNotEmpty == other.IsNotEmpty 
+                               && other.PathChain.Length == PathChain.Length
+                               && IsThis == other.IsThis 
+                               && IsParent == other.IsParent;
+
+            if (!basicEquals) return false;
+            
+            for (var index = 0; index < PathChain.Length; index++)
+            {
+                if (!PathChain[index].Equals(other.PathChain[index])) return false;
+            }
+
+            return true;
+        }
+
+        public bool Equals(string other)
+        {
+            return string.Equals(other, ToString(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is PathSegment other && Equals(other);
+        }
+
+        public override int GetHashCode() => _hashCode;
+
+        public override string ToString()
+        {
+            return string.Join<ChainSegment>(".", PathChain);
+        }
+
+        private int GetHashCodeImpl()
+        {
+            unchecked
+            {
+                var hashCode = IsNotEmpty.GetHashCode();
+                hashCode = (hashCode * 397) ^ IsThis.GetHashCode();
+                hashCode = (hashCode * 397) ^ IsParent.GetHashCode();
+
+                for (var index = 0; index < PathChain.Length; index++)
+                {
+                    hashCode = (hashCode * 397) ^ PathChain[index].GetHashCode();
+                }
+                
+                return hashCode;
+            }
+        }
     }
 }

--- a/source/Handlebars/Pools/BindingContext.Pool.cs
+++ b/source/Handlebars/Pools/BindingContext.Pool.cs
@@ -52,7 +52,6 @@ namespace HandlebarsDotNet
                     item.InlinePartialTemplates.Clear();
                     item.Bag.Clear();
 
-                    item.RootDataObject.Clear();
                     item.BlockParamsObject.OptionalClear();
                     item.ContextDataObject.OptionalClear();
                     

--- a/source/Handlebars/StringUtils/Substring.cs
+++ b/source/Handlebars/StringUtils/Substring.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -14,34 +15,19 @@ namespace HandlebarsDotNet.StringUtils
         private readonly int _start;
         public readonly int Length;
 
-        public static IReadOnlyList<Substring> Split(Substring str, char separator, StringSplitOptions options = StringSplitOptions.None)
+        public static bool EqualsIgnoreCase(Substring a, Substring b)
         {
-            var result = new List<Substring>();
-            var substringStart = 0;
-            var substringLength = 0;
-            for (var index = 0; index < str.Length; index++)
+            if (a.Length != b.Length) return false;
+
+            for (int index = 0; index < a.Length; index++)
             {
-                if (str[index] != separator)
-                {
-                    substringLength++;
-                    continue;
-                }
-
-                var substring = new Substring(str, substringStart, substringLength);
-                substringLength = 0;
-                substringStart = index + 1;
-
-                if (substring.Length != 0 || options != StringSplitOptions.RemoveEmptyEntries)
-                    result.Add(substring);
+                if (!char.ToLowerInvariant(a[index]).Equals(char.ToLowerInvariant(b[index]))) return false;
             }
 
-            if (substringLength != 0)
-            {
-                result.Add(new Substring(str, substringStart, substringLength));
-            }
-            
-            return result;
+            return true;
         }
+        
+        public static SplitEnumerator Split(Substring str, char separator, StringSplitOptions options = StringSplitOptions.None) => new SplitEnumerator(str, separator, options);
 
         public static Substring TrimStart(Substring str, char trimChar)
         {
@@ -138,6 +124,9 @@ namespace HandlebarsDotNet.StringUtils
         public override string ToString() => _str.Substring(_start, Length);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public SubstringEnumerator GetEnumerator() => new SubstringEnumerator(this);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Substring other)
         {
             if (Length != other.Length) return false;
@@ -182,6 +171,94 @@ namespace HandlebarsDotNet.StringUtils
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator Substring(string a) => new Substring(a);
+        
+        public struct SubstringEnumerator : IEnumerator<char>
+        {
+            private readonly Substring _substring;
+            private int _index;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public SubstringEnumerator(Substring substring)
+            {
+                _substring = substring;
+                _index = -1;
+            }
+            
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool MoveNext() => ++_index < _substring.Length;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Reset() => _index = -1;
+
+            public char Current => _substring[_index];
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose()
+            {
+            }
+        }
+        
+        public struct SplitEnumerator : IEnumerator<Substring>
+        {
+            private readonly Substring _substring;
+            private readonly char _separator;
+            private readonly StringSplitOptions _options;
+            
+            private Substring _current;
+            private int _index;
+
+            public SplitEnumerator(Substring substring, char separator, StringSplitOptions options = StringSplitOptions.None)
+            {
+                _substring = substring;
+                _separator = separator;
+                _options = options;
+                _current = new Substring();
+                _index = 0;
+            }
+            
+            public bool MoveNext()
+            {
+                var substringStart = _index;
+                var substringLength = 0;
+                for (; _index < _substring.Length; _index++)
+                {
+                    if (_substring[_index] != _separator)
+                    {
+                        substringLength++;
+                        continue;
+                    }
+
+                    var substring = new Substring(_substring, substringStart, substringLength);
+                    substringLength = 0;
+                    substringStart = ++_index;
+
+                    if (substring.Length != 0 || _options != StringSplitOptions.RemoveEmptyEntries)
+                    {
+                        _current = substring;
+                        return true;
+                    }
+                }
+
+                if (substringLength != 0)
+                {
+                    _current = new Substring(_substring, substringStart, substringLength);
+                    return true;
+                }
+
+                return false;
+            }
+
+            public void Reset() => _index = 0;
+
+            public Substring Current => _current;
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose()
+            {
+            }
+        }
         
         private static class Throw
         {

--- a/source/Handlebars/StringUtils/Substring.cs
+++ b/source/Handlebars/StringUtils/Substring.cs
@@ -196,6 +196,7 @@ namespace HandlebarsDotNet.StringUtils
 
             public void Dispose()
             {
+                // nothing to do here
             }
         }
         
@@ -257,6 +258,7 @@ namespace HandlebarsDotNet.StringUtils
 
             public void Dispose()
             {
+                // nothing to do here
             }
         }
         


### PR DESCRIPTION
What's inside:
- `@data` flows to child context
- helper names are case insensitive
- fixed context switch
- fixed problem with fallback to context when same name variable exists

Issues:
- found in /issues/394
- closes /issues/402
- closes /issues/401
- closes /issues/399