### PR TITLE
Properly handle empty ObjectDescriptor in hash population

### DIFF
--- a/source/Handlebars.Test/IssueTests.cs
+++ b/source/Handlebars.Test/IssueTests.cs
@@ -332,6 +332,25 @@ namespace HandlebarsDotNet.Test
             Assert.Equal(expected, actual);
         }
         
+        // issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/422
+        [Fact]
+        public void CallPartialInEach()
+        {
+            var handlebars = Handlebars.Create();
+            handlebars.RegisterTemplate("testPartial", " 42 ");
+            var source = "{{#each Fruits}}{{> testPartial aPartialParameter=\"couldBeAnything\"}}{{/each}}";
+            var template = handlebars.Compile(source);
+            var data = new
+            {
+                Fruits = new[] {"apple", "banana" }
+            };
+            
+            var actual = template(data);
+            var expected = " 42  42 ";
+            
+            Assert.Equal(expected, actual);
+        }
+        
         private class JoinHelper : IHelperDescriptor<HelperOptions>
         {
             public PathInfo Name { get; } = "join";

--- a/source/Handlebars/BindingContext.cs
+++ b/source/Handlebars/BindingContext.cs
@@ -163,13 +163,15 @@ namespace HandlebarsDotNet
         private static void PopulateHash(HashParameterDictionary hash, object from)
         {
             var descriptor = ObjectDescriptor.Create(from);
+            if (descriptor == ObjectDescriptor.Empty) return;
+            
             var accessor = descriptor.MemberAccessor;
             var properties = descriptor.GetProperties(descriptor, from);
             var enumerator = properties.GetEnumerator();
             while (enumerator.MoveNext())
             {
                 var segment = ChainSegment.Create(enumerator.Current);
-                if(hash.ContainsKey(segment)) continue;
+                if (hash.ContainsKey(segment)) continue;
                 if (!accessor.TryGetValue(@from, segment, out var value)) continue;
                 hash[segment] = value;
             }


### PR DESCRIPTION
What's inside:
- Properly handle empty ObjectDescriptor in hash population

Issues:
- closes https://github.com/Handlebars-Net/Handlebars.Net/issues/422