### PR TITLE
Fix child context creation when value is `null` when invoking partials

### DIFF
--- a/source/Handlebars.Test/IssueTests.cs
+++ b/source/Handlebars.Test/IssueTests.cs
@@ -546,5 +546,34 @@ namespace HandlebarsDotNet.Test
         {
             public string Name { get; set; }
         }
+        
+        // Issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/432
+        [Fact]
+        public void WeirdBehaviour()
+        {
+            var handlebars = Handlebars.Create();
+            handlebars.RegisterTemplate("displayListItem", "{{this}},");
+            handlebars.RegisterTemplate("displayList", "{{#each this}}{{> displayListItem}}{{/each}}");
+            
+            var template = handlebars.Compile("{{> displayList TheList}}");
+            var actual1 = template(new ClassWithAList());
+            var actual2 = template(new ClassWithAListAndOtherMembers());
+            var expected = "";
+
+            Assert.Equal(expected, actual1);
+            Assert.Equal(expected, actual2);
+        }
+        
+        private class ClassWithAList
+        {
+            public IEnumerable<string> TheList { get; set; }
+        }
+
+        private class ClassWithAListAndOtherMembers
+        {
+            public IEnumerable<string> TheList { get; set; }
+            public bool SomeBool { get; set; }
+            public string SomeString { get; set; } = "I shouldn't show up!";
+        }
     }
 }

--- a/source/Handlebars/BindingContext.cs
+++ b/source/Handlebars/BindingContext.cs
@@ -151,7 +151,7 @@ namespace HandlebarsDotNet
 
         internal BindingContext CreateChildContext(object value, TemplateDelegate partialBlockTemplate = null)
         {
-            return Create(Configuration, value ?? Value, this, partialBlockTemplate ?? PartialBlockTemplate);
+            return Create(Configuration, value, this, partialBlockTemplate ?? PartialBlockTemplate);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
@@ -31,7 +31,10 @@ namespace HandlebarsDotNet.Compiler
 
             if (pex.Argument != null || partialBlockTemplate != null)
             {
-                var value = Arg<object>(FunctionBuilder.Reduce(pex.Argument, CompilationContext));
+                var value = pex.Argument != null
+                    ? Arg<object>(FunctionBuilder.Reduce(pex.Argument, CompilationContext))
+                    : bindingContext.Property(o => o.Value);
+                
                 var partialTemplate = Arg(partialBlockTemplate);
                 bindingContext = bindingContext.Call(o => o.CreateChildContext(value, partialTemplate));
             }

--- a/source/Handlebars/ObjectDescriptors/EnumerableObjectDescriptor.cs
+++ b/source/Handlebars/ObjectDescriptors/EnumerableObjectDescriptor.cs
@@ -42,9 +42,9 @@ namespace HandlebarsDotNet.ObjectDescriptors
         private static readonly MethodInfo NonGenericEnumerableObjectDescriptorFactoryMethodInfo = EnumerableObjectDescriptorType
             .GetMethod(nameof(NonGenericEnumerableObjectDescriptorFactory), BindingFlags);
 
-        private readonly IObjectDescriptorProvider _descriptorProvider;
+        private readonly ObjectDescriptorProvider _descriptorProvider;
 
-        public EnumerableObjectDescriptor(IObjectDescriptorProvider descriptorProvider)
+        public EnumerableObjectDescriptor(ObjectDescriptorProvider descriptorProvider)
         {
             _descriptorProvider = descriptorProvider;
         }
@@ -125,55 +125,55 @@ namespace HandlebarsDotNet.ObjectDescriptors
 
         private static ObjectDescriptor ArrayObjectDescriptorFactory<TValue>(IMemberAccessor accessor, ObjectDescriptor descriptor)
         {
-            return new ObjectDescriptor(typeof(TValue[]), accessor, descriptor.GetProperties, self => new ArrayIterator<TValue>());
+            return new ObjectDescriptor(typeof(TValue[]), accessor, descriptor.GetProperties, self => new ArrayIterator<TValue>(), descriptor.Dependencies);
         }
         
         private static ObjectDescriptor ListObjectDescriptorFactory<T, TValue>(IMemberAccessor accessor, ObjectDescriptor descriptor) 
             where T : class, IList<TValue>
         {
-            return new ObjectDescriptor(typeof(T), accessor, descriptor.GetProperties, self => new ListIterator<T, TValue>());
+            return new ObjectDescriptor(typeof(T), accessor, descriptor.GetProperties, self => new ListIterator<T, TValue>(), descriptor.Dependencies);
         }
         
         private static ObjectDescriptor ReadOnlyListObjectDescriptorFactory<T, TValue>(IMemberAccessor accessor, ObjectDescriptor descriptor) 
             where T : class, IReadOnlyList<TValue>
         {
-            return new ObjectDescriptor(typeof(T), accessor, descriptor.GetProperties, self => new ReadOnlyListIterator<T, TValue>());
+            return new ObjectDescriptor(typeof(T), accessor, descriptor.GetProperties, self => new ReadOnlyListIterator<T, TValue>(), descriptor.Dependencies);
         }
         
         private static ObjectDescriptor NonGenericListObjectDescriptorFactory<T>(IMemberAccessor accessor, ObjectDescriptor descriptor) 
             where T : class, IList
         {
-            return new ObjectDescriptor(typeof(T), accessor, descriptor.GetProperties, self => new ListIterator<T>());
+            return new ObjectDescriptor(typeof(T), accessor, descriptor.GetProperties, self => new ListIterator<T>(), descriptor.Dependencies);
         }
         
         private static ObjectDescriptor CollectionObjectDescriptorFactory<T, TValue>(IMemberAccessor accessor, ObjectDescriptor descriptor) 
             where T : class, ICollection<TValue>
         {
-            return new ObjectDescriptor(typeof(T), accessor, descriptor.GetProperties, self => new CollectionIterator<T, TValue>());
+            return new ObjectDescriptor(typeof(T), accessor, descriptor.GetProperties, self => new CollectionIterator<T, TValue>(), descriptor.Dependencies);
         }
         
         private static ObjectDescriptor ReadOnlyCollectionObjectDescriptorFactory<T, TValue>(IMemberAccessor accessor, ObjectDescriptor descriptor) 
             where T : class, IReadOnlyCollection<TValue>
         {
-            return new ObjectDescriptor(typeof(T), accessor, descriptor.GetProperties, self => new ReadOnlyCollectionIterator<T, TValue>());
+            return new ObjectDescriptor(typeof(T), accessor, descriptor.GetProperties, self => new ReadOnlyCollectionIterator<T, TValue>(), descriptor.Dependencies);
         }
         
         private static ObjectDescriptor NonGenericCollectionObjectDescriptorFactory<T>(IMemberAccessor accessor, ObjectDescriptor descriptor) 
             where T : class, ICollection
         {
-            return new ObjectDescriptor(typeof(T), accessor, descriptor.GetProperties, self => new CollectionIterator<T>());
+            return new ObjectDescriptor(typeof(T), accessor, descriptor.GetProperties, self => new CollectionIterator<T>(), descriptor.Dependencies);
         }
         
         private static ObjectDescriptor EnumerableObjectDescriptorFactory<T, TValue>(IMemberAccessor accessor, ObjectDescriptor descriptor) 
             where T : class, IEnumerable<TValue>
         {
-            return new ObjectDescriptor(typeof(T), accessor, descriptor.GetProperties, self => new EnumerableIterator<T, TValue>());
+            return new ObjectDescriptor(typeof(T), accessor, descriptor.GetProperties, self => new EnumerableIterator<T, TValue>(), descriptor.Dependencies);
         }
         
         private static ObjectDescriptor NonGenericEnumerableObjectDescriptorFactory<T>(IMemberAccessor accessor, ObjectDescriptor descriptor) 
             where T : class, IEnumerable
         {
-            return new ObjectDescriptor(typeof(T), accessor, descriptor.GetProperties, self => new EnumerableIterator<T>());
+            return new ObjectDescriptor(typeof(T), accessor, descriptor.GetProperties, self => new EnumerableIterator<T>(), descriptor.Dependencies);
         }
     }
 }


### PR DESCRIPTION
What's inside:
- fix child context creation when value is `null`
- fix dependency propagation to `Enumerable` descriptor

Issues:
- closes https://github.com/Handlebars-Net/Handlebars.Net/issues/432