### PR TITLE
Fix multiple block params in the same template in different blocks

### DIFF
--- a/source/Handlebars.Test/BasicIntegrationTests.cs
+++ b/source/Handlebars.Test/BasicIntegrationTests.cs
@@ -734,6 +734,23 @@ false
             var result = template(data);
             Assert.Equal("hello: foo world: bar ", result);
         }
+        
+        [Theory, ClassData(typeof(HandlebarsEnvGenerator))]
+        public void ObjectEnumeratorWithWithContainingBlockParams(IHandlebars handlebars)
+        {
+            var source = "{{#each enumerateMe as |item val|}}{{#with @item as |item2|}}{{@item2}}: {{@val}} {{/with}}{{/each}}";
+            var template = handlebars.Compile(source);
+            var data = new
+            {
+                enumerateMe = new
+                {
+                    foo = "hello",
+                    bar = "world"
+                }
+            };
+            var result = template(data);
+            Assert.Equal("hello: foo world: bar ", result);
+        }
 
         [Theory, ClassData(typeof(HandlebarsEnvGenerator))]
         public void BasicDictionaryEnumerator(IHandlebars handlebars)

--- a/source/Handlebars/Compiler/Lexer/Converter/BlockParamsConverter.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/BlockParamsConverter.cs
@@ -36,6 +36,8 @@ namespace HandlebarsDotNet.Compiler
                 }
                 else
                 {
+                    if (item is EndExpressionToken) foundBlockParams = false;
+
                     result.Add(item);
                 }
             }

--- a/source/Handlebars/Compiler/Lexer/Converter/BlockParamsConverter.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/BlockParamsConverter.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using HandlebarsDotNet.Compiler.Lexer;
 
 namespace HandlebarsDotNet.Compiler
@@ -21,28 +20,45 @@ namespace HandlebarsDotNet.Compiler
         public override IEnumerable<object> ConvertTokens(IEnumerable<object> sequence)
         {
             var result = new List<object>();
-            bool foundBlockParams = false;
+            var foundBlockParams = false;
             foreach (var item in sequence)
             {
-                if (item is BlockParameterToken blockParameterToken)
+                switch (item)
                 {
-                    if(foundBlockParams) throw new HandlebarsCompilerException("multiple blockParams expressions are not supported", blockParameterToken.Context);
+                    case BlockParameterToken blockParameterToken:
+                        BlockParamsFound(ref foundBlockParams, blockParameterToken);
+                        ConvertBlockParam(blockParameterToken, result);
+                        continue;
                     
-                    foundBlockParams = true;
-                    if(!(result[result.Count - 1] is PathExpression pathExpression)) throw new HandlebarsCompilerException("blockParams definition has incorrect syntax", blockParameterToken.Context);
-                    if(!string.Equals("as", pathExpression.Path, StringComparison.OrdinalIgnoreCase)) throw new HandlebarsCompilerException("blockParams definition has incorrect syntax", blockParameterToken.Context);
-                    
-                    result[result.Count - 1] = HandlebarsExpression.BlockParams(pathExpression.Path, blockParameterToken.Value);
+                    case EndExpressionToken _:
+                        foundBlockParams = false;
+                        break;
                 }
-                else
-                {
-                    if (item is EndExpressionToken) foundBlockParams = false;
 
-                    result.Add(item);
-                }
+                result.Add(item);
             }
 
             return result;
+        }
+
+        private static void ConvertBlockParam(BlockParameterToken blockParameterToken, List<object> result)
+        {
+            var pathExpression = result[result.Count - 1] as PathExpression;
+            VerifyBlockParamsSyntax(blockParameterToken, pathExpression);
+
+            result[result.Count - 1] = HandlebarsExpression.BlockParams(pathExpression!.Path, blockParameterToken.Value);
+        }
+
+        private static void VerifyBlockParamsSyntax(BlockParameterToken blockParameterToken, PathExpression pathExpression)
+        {
+            if (pathExpression == null) throw new HandlebarsCompilerException("blockParams definition has incorrect syntax", blockParameterToken.Context);
+            if (!string.Equals("as", pathExpression.Path, StringComparison.OrdinalIgnoreCase)) throw new HandlebarsCompilerException("blockParams definition has incorrect syntax", blockParameterToken.Context);
+        }
+
+        private static void BlockParamsFound(ref bool foundBlockParams, BlockParameterToken blockParameterToken)
+        {
+            if (foundBlockParams) throw new HandlebarsCompilerException("multiple blockParams expressions are not supported", blockParameterToken.Context);
+            foundBlockParams = true;
         }
     }
 }


### PR DESCRIPTION
What's inside:
- fixes `HandlebarsCompilerException` when template contains multiple `blockParams` in different blocks