### PR TITLE
Only parse comments as layout when they are not escaped

### DIFF
--- a/source/Handlebars.Test/ViewEngine/ViewEngineTests.cs
+++ b/source/Handlebars.Test/ViewEngine/ViewEngineTests.cs
@@ -130,6 +130,23 @@ namespace HandlebarsDotNet.Test.ViewEngine
             Assert.Equal("This is the THING", output);
         }
 
+        [Fact]
+        public void CanIgnoreCommentsContainingHtml()
+        {
+            var files = new FakeFileSystem()
+            {
+                { "views\\layout.hbs", "Start\r\n{{{body}}}\r\nEnd" },
+                { "views\\someview.hbs", "{{!< layout}}\r\n\r\nTemplate\r\n{{!--\r\n<div>Commented out HTML</div>\r\n--}}" },
+            };
+
+            var handlebarsConfiguration = new HandlebarsConfiguration() { FileSystem = files };
+            var handlebars = Handlebars.Create(handlebarsConfiguration);
+            var render = handlebars.CompileView("views\\someview.hbs");
+            var output = render(null);
+
+            Assert.Equal("Start\r\n\r\nTemplate\r\n\r\nEnd", output);
+        }
+
         //We have a fake file system. Difference frameworks and apps will use 
         //different file systems.
         class FakeFileSystem : ViewEngineFileSystem, IEnumerable

--- a/source/Handlebars/Compiler/Lexer/Parsers/CommentParser.cs
+++ b/source/Handlebars/Compiler/Lexer/Parsers/CommentParser.cs
@@ -10,8 +10,8 @@ namespace HandlebarsDotNet.Compiler.Lexer
             if (!IsComment(reader)) return null;
          
             Token token = null;
-            var buffer = AccumulateComment(reader).Trim();
-            if (buffer.StartsWith("<")) //syntax for layout is {{!< layoutname }} - i.e. its inside a comment block
+            var buffer = AccumulateComment(reader, out bool isEscaped).Trim();
+            if (buffer.StartsWith("<") && !isEscaped) //syntax for layout is {{!< layoutname }} - i.e. its inside a comment block
             {
                 token = Token.Layout(buffer.Substring(1).Trim());
             }
@@ -26,7 +26,7 @@ namespace HandlebarsDotNet.Compiler.Lexer
             return peek == '!';
         }
 
-        private static string AccumulateComment(ExtendedStringReader reader)
+        private static string AccumulateComment(ExtendedStringReader reader, out bool isEscaped)
         {
             reader.Read();
             bool? escaped = null;
@@ -53,7 +53,8 @@ namespace HandlebarsDotNet.Compiler.Lexer
                         buffer.Append((char)node);
                     }
                 }
-                
+
+                isEscaped = escaped.Value;
                 return buffer.ToString();
             }
         }


### PR DESCRIPTION
Fixes #437

This lets `CommentParser.AccumulateComment` return whether the comment is an ‘escaped’ comment (i.e. starting with `--`), and only parses a layout token when it is _not escaped_.