### PR TITLE
Render layouts using LayoutViewModel instead of DynamicViewModel

### DIFF
--- a/source/Handlebars.Test/ViewEngine/ViewEngineTests.cs
+++ b/source/Handlebars.Test/ViewEngine/ViewEngineTests.cs
@@ -190,6 +190,29 @@ namespace HandlebarsDotNet.Test.ViewEngine
         }
 
         [Fact]
+        public void CanBindToModelInNestedLayout()
+        {
+            var files = new FakeFileSystem
+                        {
+                            { "views\\parent_layout.hbs", "Parent layout: {{property}}\r\n{{{body}}}" },
+                            { "views\\layout.hbs", "{{!< parent_layout}}\r\nLayout: {{property}}\r\n{{{body}}}" },
+                            { "views\\someview.hbs", "{{!< layout}}\r\n\r\nBody: {{property}}" },
+                        };
+
+            var handlebarsConfiguration = new HandlebarsConfiguration { FileSystem = files };
+            var handlebars = Handlebars.Create(handlebarsConfiguration);
+            var render = handlebars.CompileView("views\\someview.hbs");
+            var output = render(
+                new
+                {
+                    property = "Foo"
+                }
+            );
+
+            Assert.Equal("Parent layout: Foo\r\nLayout: Foo\r\n\r\nBody: Foo", output);
+        }
+
+        [Fact]
         public void CanUseNullModelInLayout()
         {
             var files = new FakeFileSystem

--- a/source/Handlebars.Test/ViewEngine/ViewEngineTests.cs
+++ b/source/Handlebars.Test/ViewEngine/ViewEngineTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Xunit;
 
@@ -50,7 +52,7 @@ namespace HandlebarsDotNet.Test.ViewEngine
             //Then the correct output should be rendered
             Assert.Equal("layout start\r\nThis is the body\r\nlayout end", output);
         }
-        
+
         [Fact]
         public void CanLoadAViewWithALayoutInTheRoot()
         {
@@ -63,7 +65,7 @@ namespace HandlebarsDotNet.Test.ViewEngine
             };
 
             //When a viewengine renders that view
-            var handlebars = HandlebarsDotNet.Handlebars.Create(new HandlebarsConfiguration() {FileSystem = files});
+            var handlebars = Handlebars.Create(new HandlebarsConfiguration() {FileSystem = files});
             var render = handlebars.CompileView("views\\someview.hbs");
             var output = render(null);
 
@@ -110,7 +112,7 @@ namespace HandlebarsDotNet.Test.ViewEngine
             //Then the correct output should be rendered
             Assert.Equal("layout start\r\nThis is the body\r\nlayout end", output);
         }
-        
+
         [Fact]
         public void CanRenderAGlobalVariable()
         {
@@ -147,7 +149,189 @@ namespace HandlebarsDotNet.Test.ViewEngine
             Assert.Equal("Start\r\n\r\nTemplate\r\n\r\nEnd", output);
         }
 
-        //We have a fake file system. Difference frameworks and apps will use 
+        [Fact]
+        public void CanUseDictionaryModelInLayout()
+        {
+            var files = new FakeFileSystem
+                        {
+                            { "views\\layout.hbs", "Layout: {{property}}\r\n{{{body}}}" },
+                            { "views\\someview.hbs", "{{!< layout}}\r\n\r\nBody: {{property}}" },
+                        };
+
+            var handlebarsConfiguration = new HandlebarsConfiguration { FileSystem = files };
+            var handlebars = Handlebars.Create(handlebarsConfiguration);
+            var render = handlebars.CompileView("views\\someview.hbs");
+            var output = render(
+                new Dictionary<string, object>
+                {
+                    { "property", "Foo" },
+                }
+            );
+
+            Assert.Equal("Layout: Foo\r\n\r\nBody: Foo", output);
+        }
+
+        [Fact]
+        public void CanUseDynamicModelInLayout()
+        {
+            var files = new FakeFileSystem
+                        {
+                            { "views\\layout.hbs", "Layout: {{property}}\r\n{{{body}}}" },
+                            { "views\\someview.hbs", "{{!< layout}}\r\n\r\nBody: {{property}}" },
+                        };
+
+            dynamic model = new MyDynamicModel();
+            var handlebarsConfiguration = new HandlebarsConfiguration { FileSystem = files };
+            var handlebars = Handlebars.Create(handlebarsConfiguration);
+            var render = handlebars.CompileView("views\\someview.hbs");
+            var output = render(model);
+
+            Assert.Equal("Layout: Foo\r\n\r\nBody: Foo", output);
+        }
+
+        [Fact]
+        public void CanUseNullModelInLayout()
+        {
+            var files = new FakeFileSystem
+                        {
+                            { "views\\layout.hbs", "Layout: {{property}}\r\n{{{body}}}" },
+                            { "views\\someview.hbs", "{{!< layout}}\r\n\r\nBody: {{property}}" },
+                        };
+
+            var handlebarsConfiguration = new HandlebarsConfiguration { FileSystem = files };
+            var handlebars = Handlebars.Create(handlebarsConfiguration);
+            var render = handlebars.CompileView("views\\someview.hbs");
+            var output = render(null);
+
+            Assert.Equal("Layout: \r\n\r\nBody: ", output);
+        }
+
+        [Fact]
+        public void CanIterateOverDictionaryInLayout()
+        {
+            var files = new FakeFileSystem
+                        {
+                            { "views\\layout.hbs", "Layout: {{#each this}}{{#if @First}}First:{{/if}}{{#if @Last}}Last:{{/if}}{{@Key}}={{@Value}};{{/each}}{{{body}}}" },
+                            { "views\\someview.hbs", "{{!< layout}} View" },
+                        };
+
+            var handlebarsConfiguration = new HandlebarsConfiguration
+                                          {
+                                              FileSystem = files,
+                                              Compatibility =
+                                              {
+                                                  SupportLastInObjectIterations = true,
+                                              },
+                                          };
+            var handlebars = Handlebars.Create(handlebarsConfiguration);
+            var render = handlebars.CompileView("views\\someview.hbs");
+            var output = render(
+                new Dictionary<string, object>
+                {
+                    { "Foo", "Bar" },
+                    { "Baz", "Foo" },
+                    { "Bar", "Baz" },
+                }
+            );
+
+            Assert.Equal("Layout: First:Foo=Bar;Baz=Foo;Last:Bar=Baz; View", output);
+        }
+
+        [Fact]
+        public void CanIterateOverObjectInLayout()
+        {
+            var files = new FakeFileSystem
+                        {
+                            { "views\\layout.hbs", "Layout: {{#each this}}{{#if @First}}First:{{/if}}{{#if @Last}}Last:{{/if}}{{@Key}}={{@Value}};{{/each}}{{{body}}}" },
+                            { "views\\someview.hbs", "{{!< layout}} View" },
+                        };
+
+            var handlebarsConfiguration = new HandlebarsConfiguration
+                                          {
+                                              FileSystem = files,
+                                              Compatibility =
+                                              {
+                                                  SupportLastInObjectIterations = true,
+                                              },
+                                          };
+            var handlebars = Handlebars.Create(handlebarsConfiguration);
+            var render = handlebars.CompileView("views\\someview.hbs");
+            var output = render(
+                new
+                {
+                    Foo = "Bar",
+                    Baz = "Foo",
+                    Bar = "Baz",
+                }
+            );
+
+            Assert.Equal("Layout: First:Foo=Bar;Baz=Foo;Last:Bar=Baz; View", output);
+        }
+
+        [Fact]
+        public void CanIterateOverEnumerableInLayout()
+        {
+            var files = new FakeFileSystem
+                        {
+                            { "views\\layout.hbs", "Layout: {{#each this}}{{#if @First}}First:{{/if}}{{#if @Last}}Last:{{/if}}{{this}};{{/each}}{{{body}}}" },
+                            { "views\\someview.hbs", "{{!< layout}} View" },
+                        };
+
+            var handlebarsConfiguration = new HandlebarsConfiguration
+                                          {
+                                              FileSystem = files,
+                                              Compatibility =
+                                              {
+                                                  SupportLastInObjectIterations = true,
+                                              },
+                                          };
+            var handlebars = Handlebars.Create(handlebarsConfiguration);
+            var render = handlebars.CompileView("views\\someview.hbs");
+            var output = render(
+                Enumerable.Range(0, 5)
+            );
+
+            Assert.Equal("Layout: First:0;1;2;3;Last:4; View", output);
+        }
+
+        [Fact]
+        public void CanIterateOverNullModelInLayout()
+        {
+            var files = new FakeFileSystem
+                        {
+                            { "views\\layout.hbs", "Layout: {{#each this}}{{#if @First}}First:{{/if}}{{#if @Last}}Last:{{/if}}{{this}};{{/each}}{{{body}}}" },
+                            { "views\\someview.hbs", "{{!< layout}} View" },
+                        };
+
+            var handlebarsConfiguration = new HandlebarsConfiguration
+                                          {
+                                              FileSystem = files,
+                                              Compatibility =
+                                              {
+                                                  SupportLastInObjectIterations = true,
+                                              },
+                                          };
+            var handlebars = Handlebars.Create(handlebarsConfiguration);
+            var render = handlebars.CompileView("views\\someview.hbs");
+            var output = render(null);
+
+            Assert.Equal("Layout:  View", output);
+        }
+
+        private class MyDynamicModel: DynamicObject
+        {
+            private readonly Dictionary<string, object> _properties =
+                new Dictionary<string, object>
+                {
+                    { "property", "Foo" },
+                };
+
+            public override IEnumerable<string> GetDynamicMemberNames() => _properties.Keys;
+            public override bool TryGetMember(GetMemberBinder binder, out object result) =>
+                _properties.TryGetValue(binder.Name, out result);
+        }
+
+        //We have a fake file system. Difference frameworks and apps will use
         //different file systems.
         class FakeFileSystem : ViewEngineFileSystem, IEnumerable
         {

--- a/source/Handlebars.Test/ViewEngine/ViewEngineTests.cs
+++ b/source/Handlebars.Test/ViewEngine/ViewEngineTests.cs
@@ -300,14 +300,7 @@ namespace HandlebarsDotNet.Test.ViewEngine
                             { "views\\someview.hbs", "{{!< layout}} View" },
                         };
 
-            var handlebarsConfiguration = new HandlebarsConfiguration
-                                          {
-                                              FileSystem = files,
-                                              Compatibility =
-                                              {
-                                                  SupportLastInObjectIterations = true,
-                                              },
-                                          };
+            var handlebarsConfiguration = new HandlebarsConfiguration { FileSystem = files };
             var handlebars = Handlebars.Create(handlebarsConfiguration);
             var render = handlebars.CompileView("views\\someview.hbs");
             var output = render(
@@ -326,14 +319,7 @@ namespace HandlebarsDotNet.Test.ViewEngine
                             { "views\\someview.hbs", "{{!< layout}} View" },
                         };
 
-            var handlebarsConfiguration = new HandlebarsConfiguration
-                                          {
-                                              FileSystem = files,
-                                              Compatibility =
-                                              {
-                                                  SupportLastInObjectIterations = true,
-                                              },
-                                          };
+            var handlebarsConfiguration = new HandlebarsConfiguration { FileSystem = files };
             var handlebars = Handlebars.Create(handlebarsConfiguration);
             var render = handlebars.CompileView("views\\someview.hbs");
             var output = render(null);

--- a/source/Handlebars/Compiler/HandlebarsCompiler.cs
+++ b/source/Handlebars/Compiler/HandlebarsCompiler.cs
@@ -78,8 +78,7 @@ namespace HandlebarsDotNet.Compiler
                 compiledView(textWriter, context);
                 var inner = innerWriter.ToString();
 
-                var vmContext = new [] {new {body = inner}, context.Value};
-                var viewModel = new DynamicViewModel(vmContext);
+                var viewModel = new LayoutViewModel(inner, context.Value);
                 bindingContext.Value = viewModel;
 
                 compiledLayout(writer, bindingContext);

--- a/source/Handlebars/Configuration/HandlebarsConfigurationAdapter.cs
+++ b/source/Handlebars/Configuration/HandlebarsConfigurationAdapter.cs
@@ -121,6 +121,7 @@ namespace HandlebarsDotNet
                     new GenericDictionaryObjectDescriptorProvider(),
                     new ReadOnlyStringDictionaryObjectDescriptorProvider(),
                     new StringDictionaryObjectDescriptorProvider(),
+                    new LayoutViewModel.DescriptorProvider(),
                 }
                 .AddMany(descriptorProviders);
 

--- a/source/Handlebars/LayoutViewModel.cs
+++ b/source/Handlebars/LayoutViewModel.cs
@@ -11,7 +11,8 @@ namespace HandlebarsDotNet
 {
     internal class LayoutViewModel
     {
-        private static readonly ChainSegment _bodyChainSegment = ChainSegment.Create("body");
+        private static readonly ChainSegment BodyChainSegment = ChainSegment.Create("body");
+
         private readonly string _body;
         private readonly object _value;
         private readonly ObjectDescriptor _valueDescriptor;
@@ -25,21 +26,22 @@ namespace HandlebarsDotNet
 
         internal class DescriptorProvider: IObjectDescriptorProvider
         {
-            private static readonly object[] _bodyProperties = { _bodyChainSegment };
-            private static readonly Type _type = typeof(LayoutViewModel);
+            private static readonly object[] BodyProperties = { BodyChainSegment };
+            private static readonly Type Type = typeof(LayoutViewModel);
+
             private readonly ObjectDescriptor _descriptor;
 
             public DescriptorProvider()
             {
                 _descriptor = new ObjectDescriptor(
-                    _type,
+                    Type,
                     new MemberAccessor(),
                     (_, o) =>
                     {
                         var vm = (LayoutViewModel) o;
                         IEnumerable valueProperties = vm._valueDescriptor.GetProperties(vm._valueDescriptor, vm._value);
 
-                        return _bodyProperties
+                        return BodyProperties
                            .Concat(valueProperties.Cast<object>());
                     },
                     _ => new Iterator()
@@ -48,7 +50,7 @@ namespace HandlebarsDotNet
 
             public bool TryGetDescriptor(Type type, out ObjectDescriptor value)
             {
-                if (type != _type)
+                if (type != Type)
                 {
                     value = ObjectDescriptor.Empty;
                     return false;
@@ -65,7 +67,7 @@ namespace HandlebarsDotNet
             {
                 var vm = (LayoutViewModel) instance;
 
-                if (memberName.Equals(_bodyChainSegment))
+                if (memberName.Equals(BodyChainSegment))
                 {
                     value = vm._body;
                     return true;

--- a/source/Handlebars/LayoutViewModel.cs
+++ b/source/Handlebars/LayoutViewModel.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections;
+using System.Linq;
+using HandlebarsDotNet.Compiler;
+using HandlebarsDotNet.Iterators;
+using HandlebarsDotNet.MemberAccessors;
+using HandlebarsDotNet.ObjectDescriptors;
+using HandlebarsDotNet.PathStructure;
+
+namespace HandlebarsDotNet
+{
+    internal class LayoutViewModel
+    {
+        private static readonly ChainSegment _bodyChainSegment = ChainSegment.Create("body");
+        private readonly string _body;
+        private readonly object _value;
+        private readonly ObjectDescriptor _valueDescriptor;
+
+        public LayoutViewModel(string body, object value)
+        {
+            _body = body;
+            _value = value;
+            _valueDescriptor = ObjectDescriptor.Create(value);
+        }
+
+        internal class DescriptorProvider: IObjectDescriptorProvider
+        {
+            private static readonly object[] _bodyProperties = { _bodyChainSegment };
+            private static readonly Type _type = typeof(LayoutViewModel);
+            private readonly ObjectDescriptor _descriptor;
+
+            public DescriptorProvider()
+            {
+                _descriptor = new ObjectDescriptor(
+                    _type,
+                    new MemberAccessor(),
+                    (_, o) =>
+                    {
+                        var vm = (LayoutViewModel) o;
+                        IEnumerable valueProperties = vm._valueDescriptor.GetProperties(vm._valueDescriptor, vm._value);
+
+                        return _bodyProperties
+                           .Concat(valueProperties.Cast<object>());
+                    },
+                    _ => new Iterator()
+                );
+            }
+
+            public bool TryGetDescriptor(Type type, out ObjectDescriptor value)
+            {
+                if (type != _type)
+                {
+                    value = ObjectDescriptor.Empty;
+                    return false;
+                }
+
+                value = _descriptor;
+                return true;
+            }
+        }
+
+        private class MemberAccessor: IMemberAccessor
+        {
+            public bool TryGetValue(object instance, ChainSegment memberName, out object value)
+            {
+                var vm = (LayoutViewModel) instance;
+
+                if (memberName.Equals(_bodyChainSegment))
+                {
+                    value = vm._body;
+                    return true;
+                }
+
+                var memberAccessor = vm._valueDescriptor.MemberAccessor;
+
+                if (memberAccessor != null)
+                    return memberAccessor.TryGetValue(vm._value, memberName, out value);
+
+                value = default;
+                return false;
+            }
+        }
+
+        private class Iterator: IIterator
+        {
+            public void Iterate(in EncodedTextWriter writer, BindingContext context, ChainSegment[] blockParamsVariables, object input, TemplateDelegate template, TemplateDelegate ifEmpty)
+            {
+                var vm = (LayoutViewModel) input;
+                var iterator = vm._valueDescriptor.Iterator;
+                iterator?.Iterate(writer, context, blockParamsVariables, vm._value, template, ifEmpty);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #440.

Because `DynamicViewModel` is ‘too flexible’, it is difficult to provide a fully working `ObjectDescriptor` for it. Instead, this introduces a new, more limited `LayoutViewModel`, which intercepts binding expressions for `body`, but forwards everything else, including iteration, to the main view’s model. `DynamicViewModel` is left unmodified, since it’s public and it’s unclear whether people actually use it.