### PR TITLE
Improve performance for large arrays (10.000+)

### DIFF
--- a/source/Handlebars.Benchmark/LargeArray.cs
+++ b/source/Handlebars.Benchmark/LargeArray.cs
@@ -10,27 +10,20 @@ namespace HandlebarsNet.Benchmark
     public class LargeArray
     {
         private object _data;
-        private HandlebarsTemplate<TextWriter, object, object> _default;
+        private HandlebarsTemplate<object, object> _default;
 
-        [Params(1, 2, 3, 4, 5)]
+        [Params(20000, 40000, 80000)]
         public int N { get; set; }
         
         [GlobalSetup]
         public void Setup()
         {
             const string template = @"{{#each this}}{{this}}{{/each}}";
-
-            var handlebars = Handlebars.Create();
-
-            using (var reader = new StringReader(template))
-            {
-                _default = handlebars.Compile(reader);
-            }
-
-            _data = Enumerable.Range(0, (int) Math.Pow(10, N)).ToList();
+            _default = Handlebars.Compile(template);
+            _data = Enumerable.Range(0, N).ToList();
         }
         
         [Benchmark]
-        public void Default() => _default(TextWriter.Null, _data);
+        public void Default() => _default(_data);
     }
 }

--- a/source/Handlebars.Benchmark/LargeArray.cs
+++ b/source/Handlebars.Benchmark/LargeArray.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using HandlebarsDotNet;
+
+namespace HandlebarsNet.Benchmark
+{
+    public class LargeArray
+    {
+        private object _data;
+        private HandlebarsTemplate<TextWriter, object, object> _default;
+
+        [Params(1, 2, 3, 4, 5)]
+        public int N { get; set; }
+        
+        [GlobalSetup]
+        public void Setup()
+        {
+            const string template = @"{{#each this}}{{this}}{{/each}}";
+
+            var handlebars = Handlebars.Create();
+
+            using (var reader = new StringReader(template))
+            {
+                _default = handlebars.Compile(reader);
+            }
+
+            _data = Enumerable.Range(0, (int) Math.Pow(10, N)).ToList();
+        }
+        
+        [Benchmark]
+        public void Default() => _default(TextWriter.Null, _data);
+    }
+}

--- a/source/Handlebars.Benchmark/LargeArray.cs
+++ b/source/Handlebars.Benchmark/LargeArray.cs
@@ -10,7 +10,7 @@ namespace HandlebarsNet.Benchmark
     public class LargeArray
     {
         private object _data;
-        private HandlebarsTemplate<object, object> _default;
+        private HandlebarsTemplate<TextWriter, object, object> _default;
 
         [Params(20000, 40000, 80000)]
         public int N { get; set; }
@@ -19,11 +19,18 @@ namespace HandlebarsNet.Benchmark
         public void Setup()
         {
             const string template = @"{{#each this}}{{this}}{{/each}}";
-            _default = Handlebars.Compile(template);
+
+            var handlebars = Handlebars.Create();
+
+            using (var reader = new StringReader(template))
+            {
+                _default = handlebars.Compile(reader);
+            }
+
             _data = Enumerable.Range(0, N).ToList();
         }
         
         [Benchmark]
-        public void Default() => _default(_data);
+        public void Default() => _default(TextWriter.Null, _data);
     }
 }

--- a/source/Handlebars/Runtime/BoxedValues.cs
+++ b/source/Handlebars/Runtime/BoxedValues.cs
@@ -34,16 +34,7 @@ namespace HandlebarsDotNet.Runtime
                 return BoxedIntegers[value];
             }
             
-            return Value(value);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static object Value<T>(T value) where T: struct =>
-            BoxedContainer<T>.Boxed.GetOrAdd(value, v => (object) v);
-
-        private static class BoxedContainer<T>
-        {
-            public static readonly LookupSlim<T, object, IEqualityComparer<T>> Boxed = new LookupSlim<T, object, IEqualityComparer<T>>(EqualityComparer<T>.Default);
+            return value;
         }
     }
 }


### PR DESCRIPTION
When rendering templates with large arrays, execution time grows exponentially.
Take the following measurements:

```
Elements | Rendering Time (ms)
  20.000 |          5.500
  40.000 |         20.000
  80.000 |         80.000
```

produced by the following minimal example:

```csharp
class Program
	{
		static void Main(string[] args)
		{
			Stopwatch sw = new Stopwatch();
			
			var source = @"{{#each this}}{{this}}{{/each}}";
			var template = Handlebars.Compile(source);
			var data = Enumerable.Range(0, 20000).ToList();
			
			sw.Start();
			template(data);
			sw.Stop();
			Console.WriteLine($"Filling 20.000 Elements took {sw.ElapsedMilliseconds} ms");
			
			sw.Restart();
			data = Enumerable.Range(0, 40000).ToList();
			template(data);
			sw.Stop();
			Console.WriteLine($"Filling 40.000 Elements took {sw.ElapsedMilliseconds} ms");
			
			sw.Restart();
			data = Enumerable.Range(0, 80000).ToList();
			template(data);
			sw.Stop();
			Console.WriteLine($"Filling 80.000 Elements took {sw.ElapsedMilliseconds} ms");
		}
	}
```

The issue originated from the cache for the iterators contained in `BoxedValues.cs`.
In opposite to the desired reduced memory usage, memory usage actually also explodes for the example show above.

This pull request removes the cache, leaving the small boxing-cache for integer values between 0 and 20.
Furthermore, it adds a benchmark for the execution time.
For some reasons, I could not reproduce the dramatic execution times stated here with this benchmark, although it uses the same code. Anyone has an idea, why the benchmarks execute faster than expected?