### PR TITLE
HtmlEncoding consistent with rules in handlebars.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,43 @@ public void HelperWithDotSeparatedName()
 }
 ```
 
+#### HtmlEncoder
+Used to switch between the legacy Handlebars.Net and the canonical Handlebars rules (or a custom implementation).\
+For Handlebars.Net 2.x.x `HtmlEncoderLegacy` is the default.
+
+`HtmlEncoder`\
+Implements the canonical Handlebars rules.
+
+`HtmlEncoderLegacy`\
+Will not encode:\
+= (equals)\
+&#96; (backtick)\
+' (single quote)
+
+Will encode non-ascii characters `â`, `ß`, ...\
+Into HTML entities (`&lt;`, `&#226;`, `&#223;`, ...).
+
+##### Areas
+- `Runtime`
+
+##### Example
+```c#
+[Fact]
+public void UseCanonicalHtmlEncodingRules()
+{
+    var handlebars = Handlebars.Create();
+    handlebars.Configuration.TextEncoder = new HtmlEncoder();
+
+    var source = "{{Text}}";
+    var value = new { Text = "< â" };
+
+    var template = handlebars.Compile(source);
+    var actual = template(value);
+            
+    Assert.Equal("&lt; â", actual);
+}
+```
+
 ## Performance
 
 ### Compilation

--- a/source/Handlebars.Test/BasicIntegrationTests.cs
+++ b/source/Handlebars.Test/BasicIntegrationTests.cs
@@ -37,6 +37,13 @@ namespace HandlebarsDotNet.Test
     
     public class BasicIntegrationTests
     {
+        private static string HtmlEncodeStringHelper(IHandlebars handlebars, string inputString)
+        {
+            using var stringWriter = new System.IO.StringWriter();
+            handlebars.Configuration.TextEncoder.Encode(inputString, stringWriter);
+            return stringWriter.ToString();
+        }
+
         [Theory]
         [ClassData(typeof(HandlebarsEnvGenerator))]
         public void BasicEnumerableFormatter(IHandlebars handlebars)
@@ -98,7 +105,9 @@ namespace HandlebarsDotNet.Test
                 name = "Handlebars.Net"
             };
             var result = template(data);
-            Assert.Equal("Hello, ('foo' is undefined)!", result);
+
+            var expected = HtmlEncodeStringHelper(handlebars, "Hello, ('foo' is undefined)!");
+            Assert.Equal(expected, result);
         }
         
         [Theory, ClassData(typeof(HandlebarsEnvGenerator))]
@@ -114,7 +123,9 @@ namespace HandlebarsDotNet.Test
                 name = "Handlebars.Net"
             };
             var result = template(data);
-            Assert.Equal("Hello, ('foo' is undefined)!", result);
+
+            var expected = HtmlEncodeStringHelper(handlebars, "Hello, ('foo' is undefined)!");
+            Assert.Equal(expected, result);
         }
         
         [Theory, ClassData(typeof(HandlebarsEnvGenerator))]
@@ -355,7 +366,9 @@ false
                 nestedObject = "Relative dots, yay"
             };
             var result = template(data);
-            Assert.Equal("{ nestedObject = Relative dots, yay }", result);
+
+            var expected = HtmlEncodeStringHelper(handlebars, "{ nestedObject = Relative dots, yay }");
+            Assert.Equal(expected, result);
         }
 
         [Theory, ClassData(typeof(HandlebarsEnvGenerator))]

--- a/source/Handlebars.Test/BasicIntegrationTests.cs
+++ b/source/Handlebars.Test/BasicIntegrationTests.cs
@@ -2013,10 +2013,7 @@ false
 
             var config = new HandlebarsConfiguration
             {
-                Compatibility =
-                {
-                    UseLegacyHandlebarsNetHtmlEncoding = useLegacyHandlebarsNetHtmlEncoding
-                }
+                TextEncoder = useLegacyHandlebarsNetHtmlEncoding ? (ITextEncoder)new HtmlEncoderLegacy() : new HtmlEncoder()
             };
             var actual = Handlebars.Create(config).Compile(template).Invoke(value);
 
@@ -2036,15 +2033,12 @@ false
 
             var config = new HandlebarsConfiguration
             {
-                Compatibility =
-                {
-                    UseLegacyHandlebarsNetHtmlEncoding = !useLegacyHandlebarsNetHtmlEncoding
-                }
+                TextEncoder = !useLegacyHandlebarsNetHtmlEncoding ? (ITextEncoder)new HtmlEncoderLegacy() : new HtmlEncoder()
             };
             var handlebars = Handlebars.Create(config);
+            handlebars.Configuration.TextEncoder = useLegacyHandlebarsNetHtmlEncoding ? (ITextEncoder)new HtmlEncoderLegacy() : new HtmlEncoder();
             var compiledTemplate = handlebars.Compile(template);
-
-            handlebars.Configuration.Compatibility.UseLegacyHandlebarsNetHtmlEncoding = useLegacyHandlebarsNetHtmlEncoding;
+            
             var actual = compiledTemplate(value);
 
             Assert.Equal(expected, actual);

--- a/source/Handlebars.Test/BasicIntegrationTests.cs
+++ b/source/Handlebars.Test/BasicIntegrationTests.cs
@@ -1986,7 +1986,57 @@ false
                 Assert.Equal("42", actual);   
             }
         }
-        
+
+        [Theory]
+        [InlineData(false, "=", "&#x3D;")]
+        [InlineData(true, "=", "=")]
+        public void HtmlEncoderCompatibilityIntegration(bool useLegacyHandlebarsNetHtmlEncoding, string inputChar, string expected)
+        {
+            var template = "{{InputChar}}";
+            var value = new
+            {
+                InputChar = inputChar
+            };
+
+            var config = new HandlebarsConfiguration
+            {
+                Compatibility =
+                {
+                    UseLegacyHandlebarsNetHtmlEncoding = useLegacyHandlebarsNetHtmlEncoding
+                }
+            };
+            var actual = Handlebars.Create(config).Compile(template).Invoke(value);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(false, "=", "&#x3D;")]
+        [InlineData(true, "=", "=")]
+        public void HtmlEncoderCompatibilityIntegration_LateChangeConfig(bool useLegacyHandlebarsNetHtmlEncoding, string inputChar, string expected)
+        {
+            var template = "{{InputChar}}";
+            var value = new
+            {
+                InputChar = inputChar
+            };
+
+            var config = new HandlebarsConfiguration
+            {
+                Compatibility =
+                {
+                    UseLegacyHandlebarsNetHtmlEncoding = !useLegacyHandlebarsNetHtmlEncoding
+                }
+            };
+            var handlebars = Handlebars.Create(config);
+            var compiledTemplate = handlebars.Compile(template);
+
+            handlebars.Configuration.Compatibility.UseLegacyHandlebarsNetHtmlEncoding = useLegacyHandlebarsNetHtmlEncoding;
+            var actual = compiledTemplate(value);
+
+            Assert.Equal(expected, actual);
+        }
+
         private class StringHelperResolver : IHelperResolver
         {
             public bool TryResolveHelper(PathInfo name, Type targetType, out IHelperDescriptor<HelperOptions> helper)

--- a/source/Handlebars.Test/BasicIntegrationTests.cs
+++ b/source/Handlebars.Test/BasicIntegrationTests.cs
@@ -28,6 +28,7 @@ namespace HandlebarsDotNet.Test
                 types.Add(typeof(Dictionary<long, object>));
                 types.Add(typeof(Dictionary<string, string>));
             })),
+            Handlebars.Create(new HandlebarsConfiguration().Configure(o => o.TextEncoder = new HtmlEncoder())),
         };
 
         public IEnumerator<object[]> GetEnumerator() => _data.Select(o => new object[] { o }).GetEnumerator();

--- a/source/Handlebars.Test/HtmlEncoderLegacyTests.cs
+++ b/source/Handlebars.Test/HtmlEncoderLegacyTests.cs
@@ -3,32 +3,31 @@ using Xunit;
 
 namespace HandlebarsDotNet.Test
 {
-    public class HtmlEncoderTests
+    public class HtmlEncoderLegacyTests
     {
-        private readonly HtmlEncoder _htmlEncoder;
+        private readonly HtmlEncoderLegacy _htmlEncoderLegacy;
 
-        public HtmlEncoderTests()
+        public HtmlEncoderLegacyTests()
         {
-            _htmlEncoder = new HtmlEncoder();
+            _htmlEncoderLegacy = new HtmlEncoderLegacy();
         }
 
         [Theory]
-        // Escape chars based on https://github.com/handlebars-lang/handlebars.js/blob/master/lib/handlebars/utils.js
         [InlineData("&", "&amp;")]
         [InlineData("<", "&lt;")]
         [InlineData(">", "&gt;")]
         [InlineData("\"", "&quot;")]
-        [InlineData("'", "&#x27;")]
-        [InlineData("`", "&#x60;")]
-        [InlineData("=", "&#x3D;")]
+        [InlineData("â", "&#226;")]
 
         // Don't escape.
-        [InlineData("â", "â")]
-        public void EscapeCorrectCharacters(string input, string expected)
+        [InlineData("'", "'")]
+        [InlineData("`", "`")]
+        [InlineData("=", "=")]
+        public void EscapeCorrectCharactersHandlebarsNetLegacyRules(string input, string expected)
         {
             using var writer = new StringWriter();
 
-            _htmlEncoder.Encode(input, writer);
+            _htmlEncoderLegacy.Encode(input, writer);
 
             Assert.Equal(expected, writer.ToString());
         }
@@ -41,16 +40,18 @@ namespace HandlebarsDotNet.Test
         [InlineData("<", "&lt;")]
         [InlineData(">", "&gt;")]
         [InlineData("  >  ", "  &gt;  ")]
+        [InlineData("�", "&#65533;")]
+        [InlineData("�a", "&#65533;a")]
         [InlineData("\"", "&quot;")]
         [InlineData("&a&", "&amp;a&amp;")]
         [InlineData("a&a", "a&amp;a")]
-        public void EncodeTest(string input, string expected)
+        public void EncodeTestHandlebarsNetLegacyRules(string input, string expected)
         {
             // Arrange
             using var writer = new StringWriter();
 
             // Act
-            _htmlEncoder.Encode(input, writer);
+            _htmlEncoderLegacy.Encode(input, writer);
 
             // Assert
             Assert.Equal(expected, writer.ToString());

--- a/source/Handlebars.Test/HtmlEncoderLegacyTests.cs
+++ b/source/Handlebars.Test/HtmlEncoderLegacyTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Text;
 using Xunit;
 
 namespace HandlebarsDotNet.Test
@@ -54,6 +55,35 @@ namespace HandlebarsDotNet.Test
             _htmlEncoderLegacy.Encode(input, writer);
 
             // Assert
+            Assert.Equal(expected, writer.ToString());
+        }
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("a", "a")]
+        [InlineData("<", "&lt;")]
+        public void EncodeStringBuilderOverload(string input, string expected)
+        {
+            using var writer = new StringWriter();
+
+            var inputStringBuilder = input == null ? null : new StringBuilder(input);
+
+            _htmlEncoderLegacy.Encode(inputStringBuilder, writer);
+
+            Assert.Equal(expected, writer.ToString());
+        }
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("a", "a")]
+        [InlineData("<", "&lt;")]
+        public void EncodeCharEnumeratorOverload(string input, string expected)
+        {
+            using var writer = new StringWriter();
+
+            _htmlEncoderLegacy.Encode(input?.GetEnumerator(), writer);
+
             Assert.Equal(expected, writer.ToString());
         }
     }

--- a/source/Handlebars.Test/HtmlEncoderTests.cs
+++ b/source/Handlebars.Test/HtmlEncoderTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Text;
 using Xunit;
 
 namespace HandlebarsDotNet.Test
@@ -53,6 +54,35 @@ namespace HandlebarsDotNet.Test
             _htmlEncoder.Encode(input, writer);
 
             // Assert
+            Assert.Equal(expected, writer.ToString());
+        }
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("a", "a")]
+        [InlineData("<", "&lt;")]
+        public void EncodeStringBuilderOverload(string input, string expected)
+        {
+            using var writer = new StringWriter();
+
+            var inputStringBuilder = input == null ? null : new StringBuilder(input);
+
+            _htmlEncoder.Encode(inputStringBuilder, writer);
+
+            Assert.Equal(expected, writer.ToString());
+        }
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("a", "a")]
+        [InlineData("<", "&lt;")]
+        public void EncodeCharEnumeratorOverload(string input, string expected)
+        {
+            using var writer = new StringWriter();
+
+            _htmlEncoder.Encode(input?.GetEnumerator(), writer);
+
             Assert.Equal(expected, writer.ToString());
         }
     }

--- a/source/Handlebars.Test/HtmlEncoderTests.cs
+++ b/source/Handlebars.Test/HtmlEncoderTests.cs
@@ -6,6 +6,64 @@ namespace HandlebarsDotNet.Test
     public class HtmlEncoderTests
     {
         [Theory]
+        // Escape chars based on https://github.com/handlebars-lang/handlebars.js/blob/master/lib/handlebars/utils.js
+        [InlineData("&", "&amp;")]
+        [InlineData("<", "&lt;")]
+        [InlineData(">", "&gt;")]
+        [InlineData("\"", "&quot;")]
+        [InlineData("'", "&#x27;")]
+        [InlineData("`", "&#x60;")]
+        [InlineData("=", "&#x3D;")]
+
+        // Don't escape.
+        [InlineData("â", "â")]
+        public void EscapeCorrectCharacters(string input, string expected)
+        {
+            var compatibility = new Compatibility { UseLegacyHandlebarsNetHtmlEncoding = false };
+            var htmlEncoder = new HtmlEncoder(compatibility);
+            using var writer = new StringWriter();
+
+            htmlEncoder.Encode(input, writer);
+
+            Assert.Equal(expected, writer.ToString());
+        }
+
+        [Theory]
+        [InlineData("&", "&amp;")]
+        [InlineData("<", "&lt;")]
+        [InlineData(">", "&gt;")]
+        [InlineData("\"", "&quot;")]
+        [InlineData("â", "&#226;")]
+
+        // Don't escape.
+        [InlineData("'", "'")]
+        [InlineData("`", "`")]
+        [InlineData("=", "=")]
+        public void EscapeCorrectCharactersHandlebarsNetLegacyRules(string input, string expected)
+        {
+            var compatibility = new Compatibility { UseLegacyHandlebarsNetHtmlEncoding = true };
+            var htmlEncoder = new HtmlEncoder(compatibility);
+            using var writer = new StringWriter();
+
+            htmlEncoder.Encode(input, writer);
+
+            Assert.Equal(expected, writer.ToString());
+        }
+
+        [Fact]
+        public void EscapeCorrectCharacters_LateChangeConfig()
+        {
+            var compatibility = new Compatibility { UseLegacyHandlebarsNetHtmlEncoding = true };
+            var htmlEncoder = new HtmlEncoder(compatibility);
+            using var writer = new StringWriter();
+
+            compatibility.UseLegacyHandlebarsNetHtmlEncoding = false;
+            htmlEncoder.Encode("â", writer);
+
+            Assert.Equal("â", writer.ToString());
+        }
+
+        [Theory]
         [InlineData("", "")]
         [InlineData(null, "")]
         [InlineData(" ", " ")]
@@ -18,10 +76,36 @@ namespace HandlebarsDotNet.Test
         [InlineData("\"", "&quot;")]
         [InlineData("&a&", "&amp;a&amp;")]
         [InlineData("a&a", "a&amp;a")]
+        public void EncodeTestHandlebarsNetLegacyRules(string input, string expected)
+        {
+            // Arrange
+            var compatibility = new Compatibility { UseLegacyHandlebarsNetHtmlEncoding = true };
+            var htmlEncoder = new HtmlEncoder(compatibility);
+            using var writer = new StringWriter();
+
+            // Act
+            htmlEncoder.Encode(input, writer);
+
+            // Assert
+            Assert.Equal(expected, writer.ToString());
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData(null, "")]
+        [InlineData(" ", " ")]
+        [InlineData("&", "&amp;")]
+        [InlineData("<", "&lt;")]
+        [InlineData(">", "&gt;")]
+        [InlineData("  >  ", "  &gt;  ")]
+        [InlineData("\"", "&quot;")]
+        [InlineData("&a&", "&amp;a&amp;")]
+        [InlineData("a&a", "a&amp;a")]
         public void EncodeTest(string input, string expected)
         {
             // Arrange
-            var htmlEncoder = new HtmlEncoder();
+            var compatibility = new Compatibility { UseLegacyHandlebarsNetHtmlEncoding = false };
+            var htmlEncoder = new HtmlEncoder(compatibility);
             using var writer = new StringWriter();
 
             // Act

--- a/source/Handlebars.Test/TripleStashTests.cs
+++ b/source/Handlebars.Test/TripleStashTests.cs
@@ -94,11 +94,11 @@ namespace HandlebarsDotNet.Test
             var data = new
                 {
                     a_bool = false,
-                    dangerous_value = "<div>There's HTML here</div>"
+                    dangerous_value = "<div>There is HTML here</div>"
                 };
 
             var result = template(data);
-            Assert.Equal("<div>There's HTML here</div>...&lt;div&gt;There's HTML here&lt;/div&gt;...<div>There's HTML here</div>!", result);
+            Assert.Equal("<div>There is HTML here</div>...&lt;div&gt;There is HTML here&lt;/div&gt;...<div>There is HTML here</div>!", result);
         }
 	}
 }

--- a/source/Handlebars/Configuration/Compatibility.cs
+++ b/source/Handlebars/Configuration/Compatibility.cs
@@ -16,5 +16,14 @@
         /// <para>Such naming is not supported in Handlebarsjs and would break compatibility.</para>
         /// </summary>
         public bool RelaxedHelperNaming { get; set; } = false;
+
+        /// <summary>
+        /// If <see langword="true"/> enables legacy encoding rules.
+        /// <para>
+        /// This will encode non-ascii characters.
+        /// this will not encode '=', '`' or ''' (single quote).
+        /// </para>
+        /// </summary>
+        public bool UseLegacyHandlebarsNetHtmlEncoding { get; set; } = true;
     }
 }

--- a/source/Handlebars/Configuration/Compatibility.cs
+++ b/source/Handlebars/Configuration/Compatibility.cs
@@ -16,14 +16,5 @@
         /// <para>Such naming is not supported in Handlebarsjs and would break compatibility.</para>
         /// </summary>
         public bool RelaxedHelperNaming { get; set; } = false;
-
-        /// <summary>
-        /// If <see langword="true"/> enables legacy encoding rules.
-        /// <para>
-        /// This will encode non-ascii characters.
-        /// this will not encode '=', '`' or ''' (single quote).
-        /// </para>
-        /// </summary>
-        public bool UseLegacyHandlebarsNetHtmlEncoding { get; set; } = true;
     }
 }

--- a/source/Handlebars/Configuration/HandlebarsConfiguration.cs
+++ b/source/Handlebars/Configuration/HandlebarsConfiguration.cs
@@ -76,7 +76,7 @@ namespace HandlebarsDotNet
             RegisteredTemplates = new ObservableIndex<string, HandlebarsTemplate<TextWriter, object, object>, StringEqualityComparer>(stringEqualityComparer);
             
             HelperResolvers = new ObservableList<IHelperResolver>();
-            TextEncoder = new HtmlEncoder(Compatibility);
+            TextEncoder = new HtmlEncoderLegacy();
             FormatterProviders.Add(_undefinedFormatter);
         }
     }

--- a/source/Handlebars/Configuration/HandlebarsConfiguration.cs
+++ b/source/Handlebars/Configuration/HandlebarsConfiguration.cs
@@ -76,7 +76,7 @@ namespace HandlebarsDotNet
             RegisteredTemplates = new ObservableIndex<string, HandlebarsTemplate<TextWriter, object, object>, StringEqualityComparer>(stringEqualityComparer);
             
             HelperResolvers = new ObservableList<IHelperResolver>();
-            TextEncoder = new HtmlEncoder();
+            TextEncoder = new HtmlEncoder(Compatibility);
             FormatterProviders.Add(_undefinedFormatter);
         }
     }

--- a/source/Handlebars/IO/HtmlEncoder.cs
+++ b/source/Handlebars/IO/HtmlEncoder.cs
@@ -36,7 +36,7 @@ namespace HandlebarsDotNet
             EncodeImpl(text, target);
         }
 
-        private void EncodeImpl<T>(T text, TextWriter target) where T : IEnumerator<char>
+        private static void EncodeImpl<T>(T text, TextWriter target) where T : IEnumerator<char>
         {
             /*
              * Based on: https://github.com/handlebars-lang/handlebars.js/blob/master/lib/handlebars/utils.js

--- a/source/Handlebars/IO/HtmlEncoderLegacy.cs
+++ b/source/Handlebars/IO/HtmlEncoderLegacy.cs
@@ -40,7 +40,7 @@ namespace HandlebarsDotNet
             EncodeImpl(text, target);
         }
 
-        private void EncodeImpl<T>(T text, TextWriter target) where T : IEnumerator<char>
+        private static void EncodeImpl<T>(T text, TextWriter target) where T : IEnumerator<char>
         {
             while (text.MoveNext())
             {

--- a/source/Handlebars/IO/HtmlEncoderLegacy.cs
+++ b/source/Handlebars/IO/HtmlEncoderLegacy.cs
@@ -1,52 +1,55 @@
-﻿using System.Collections.Generic;
+﻿using HandlebarsDotNet.StringUtils;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
-using HandlebarsDotNet.StringUtils;
 
 namespace HandlebarsDotNet
 {
     /// <summary>
     /// <inheritdoc />
     /// Produces <c>HTML</c> safe output.
+    /// <para>
+    /// This will encode non-ascii characters.
+    /// this will not encode '=', '`' or ''' (single quote).
+    /// </para>
     /// </summary>
-    public class HtmlEncoder : ITextEncoder
+    public class HtmlEncoderLegacy : ITextEncoder
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Encode(StringBuilder text, TextWriter target)
         {
-            if(text == null || text.Length == 0) return;
-            
+            if (text == null || text.Length == 0) return;
+
             EncodeImpl(new StringBuilderEnumerator(text), target);
         }
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Encode(string text, TextWriter target)
         {
-            if(string.IsNullOrEmpty(text)) return;
-            
+            if (string.IsNullOrEmpty(text)) return;
+
             EncodeImpl(new StringEnumerator(text), target);
         }
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Encode<T>(T text, TextWriter target) where T : IEnumerator<char>
         {
-            if(text == null) return;
-            
+            if (text == null) return;
+
             EncodeImpl(text, target);
         }
 
         private void EncodeImpl<T>(T text, TextWriter target) where T : IEnumerator<char>
         {
-            /*
-             * Based on: https://github.com/handlebars-lang/handlebars.js/blob/master/lib/handlebars/utils.js
-             * As of 2021-12-20 / commit https://github.com/handlebars-lang/handlebars.js/commit/3fb331ef40ee1a8308dd83b8e5adbcd798d0adc9
-             */
             while (text.MoveNext())
             {
                 var value = text.Current;
                 switch (value)
                 {
+                    case '"':
+                        target.Write("&quot;");
+                        break;
                     case '&':
                         target.Write("&amp;");
                         break;
@@ -56,20 +59,15 @@ namespace HandlebarsDotNet
                     case '>':
                         target.Write("&gt;");
                         break;
-                    case '"':
-                        target.Write("&quot;");
-                        break;
-                    case '\'':
-                        target.Write("&#x27;");
-                        break;
-                    case '`':
-                        target.Write("&#x60;");
-                        break;
-                    case '=':
-                        target.Write("&#x3D;");
-                        break;
+
                     default:
-                        target.Write(value);
+                        if (value > 159)
+                        {
+                            target.Write("&#");
+                            target.Write((int)value);
+                            target.Write(";");
+                        }
+                        else target.Write(value);
                         break;
                 }
             }


### PR DESCRIPTION
The original issue this PR was intended to solve have been fixed in PR #477.
This PR now deals with general rules for encoding in Handlebars.Net vs handlebars.js.

Using this PR since it contains the history of how this change came to be.

~~**[WIP] Configuration.NoEscape inconsistent fix**~~

~Regarding issue: HandlebarsDotNet.Handlebars.Configuration.NoEscape Applied Inconsistently #468~

~~Change in commit: `Reset SuppressEncoding to configured instead of false.` (old) `UnencodedStatementVisitor resets value to previous` (new) makes both tests for `Handlebars_Should_Encode_Chinese` pass.~~

~~Both tests for `Handlebars_Should_Not_Encode_Chinese` still fail (output is Chinese characters, rather than expected &#xxxx;).
I don't know if this should be considered correct behavior, or possibly a separate issue.~~

Looking forward to your comments.