### PR TITLE
UnencodedStatementVisitor resets value to previously

### DIFF
--- a/source/Handlebars/Compiler/Translation/Expression/UnencodedStatementVisitor.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/UnencodedStatementVisitor.cs
@@ -20,10 +20,8 @@ namespace HandlebarsDotNet.Compiler
                 var writer = CompilationContext.Args.EncodedWriter;
                 var suppressEncoding = writer.Property(o => o.SuppressEncoding);
                 
-                var existingValue = new ExpressionContainer<bool>(Expression.Variable(typeof(bool)));
-                
                 return Block()
-                    .Parameter(existingValue)
+                    .Parameter<bool>(out var existingValue)
                     .Line(existingValue.Assign(suppressEncoding))
                     .Line(suppressEncoding.Assign(true))
                     .Line(sex)

--- a/source/Handlebars/Compiler/Translation/Expression/UnencodedStatementVisitor.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/UnencodedStatementVisitor.cs
@@ -20,10 +20,14 @@ namespace HandlebarsDotNet.Compiler
                 var writer = CompilationContext.Args.EncodedWriter;
                 var suppressEncoding = writer.Property(o => o.SuppressEncoding);
                 
+                var existingValue = new ExpressionContainer<bool>(Expression.Variable(typeof(bool)));
+                
                 return Block()
+                    .Parameter(existingValue)
+                    .Line(existingValue.Assign(suppressEncoding))
                     .Line(suppressEncoding.Assign(true))
                     .Line(sex)
-                    .Line(suppressEncoding.Assign(false));
+                    .Line(suppressEncoding.Assign(existingValue));
             }
 
             return sex;


### PR DESCRIPTION
existing value when done.

Fix #468 HandlebarsDotNet.Handlebars.Configuration.NoEscape Applied Inconsistently

Ref PR #473 [WIP] Configuration.NoEscape inconsistent fix

This PR does not deal with the question of general rules for encoding that was brought up in #473.