### PR TITLE
Last letter cut off when the string starts with the separator

### DIFF
--- a/source/Handlebars.Test/IssueTests.cs
+++ b/source/Handlebars.Test/IssueTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Dynamic;
 using System.IO;
 using System.Linq;
@@ -676,6 +677,22 @@ namespace HandlebarsDotNet.Test
             var actual = Handlebars.Create(config).Compile(template).Invoke(value);
 
             Assert.Equal(expected, actual);
+        }
+
+        // Issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/500
+        // Issue refers to the last letter being cut off when using 
+        // keys set in context
+        [Fact]
+        public void LastLetterCutOff()
+        {
+            var context = ImmutableDictionary<string, object>.Empty
+                .Add("Name", "abcd");
+
+            var template = "{{.Name}}";
+            var compiledTemplate = Handlebars.Compile(template);
+            string templateOutput = compiledTemplate(context);
+
+            Assert.Equal("abcd", templateOutput);
         }
     }
 }

--- a/source/Handlebars.Test/SubstringTests.cs
+++ b/source/Handlebars.Test/SubstringTests.cs
@@ -40,6 +40,21 @@ namespace HandlebarsDotNet.Test
                 Assert.Equal(expected[index++], split.Current) ;
             }
         }
+
+        [Theory]
+        [InlineData("ab//bc", '/', new []{ "ab", "bc" })]
+        [InlineData("/a//c/d/e//", '/', new []{ "a", "c", "d", "e" })]
+        public void SplitRemoveEmpty(string input, char splitChar, string[] expected)
+        {
+            var substring = new Substring(input);
+            var split = Substring.Split(substring, splitChar, System.StringSplitOptions.RemoveEmptyEntries);
+
+            var index = 0;
+            while (split.MoveNext())
+            {
+                Assert.Equal(expected[index++], split.Current);
+            }
+        }
         
         [Theory]
         [InlineData("abc", 'a', "bc")]

--- a/source/Handlebars.Test/SubstringTests.cs
+++ b/source/Handlebars.Test/SubstringTests.cs
@@ -37,7 +37,7 @@ namespace HandlebarsDotNet.Test
             var index = 0;
             while (split.MoveNext())
             {
-                Assert.Equal(split.Current, expected[index++]);
+                Assert.Equal(expected[index++], split.Current) ;
             }
         }
         
@@ -49,7 +49,7 @@ namespace HandlebarsDotNet.Test
             var substring = Substring.TrimStart(input, trimChar);
             
             Assert.Equal(expected, substring.ToString());
-        }
+        } 
 
         [Theory]
         [InlineData("abc", 'c', "ab")]

--- a/source/Handlebars/StringUtils/Substring.cs
+++ b/source/Handlebars/StringUtils/Substring.cs
@@ -271,11 +271,12 @@ namespace HandlebarsDotNet.StringUtils
             {
                 var substringStart = _index;
                 var substringLength = 0;
-                for (; _index < _substring.Length; _index++)
+                while (_index < _substring.Length)
                 {
                     if (_substring[_index] != _separator)
                     {
                         substringLength++;
+                        _index++;
                         continue;
                     }
 


### PR DESCRIPTION
Split Enumerator strings would have the wrong length if the string started with the separator.
This refers to issue #500 and this fix seems to have solved it.