### PR TITLE
Use `windows-2019` instead of `windows-latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@master
       - name: Setup dotnet
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        os: [ macos-latest, ubuntu-latest, windows-2019 ]
     steps:
       - uses: actions/checkout@master
       - name: Setup dotnet 2.1
@@ -47,7 +47,7 @@ jobs:
 
   sonar-ci:
     name: SonarCloud
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build 
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@master
       - name: Setup dotnet
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        os: [ macos-latest, ubuntu-latest, windows-2019 ]
     steps:
       - uses: actions/checkout@master
       - name: Setup dotnet 2.1
@@ -47,7 +47,7 @@ jobs:
         
   sonar-pr:
     name: SonarCloud
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2 
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     name: Publish
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Recently Github Actions switched to Windows 2022 as their `latest`. Unfortunately, it does not support netfx451