### PR TITLE
Fix for issue #457

### DIFF
--- a/source/Handlebars.Test/IssueTests.cs
+++ b/source/Handlebars.Test/IssueTests.cs
@@ -623,7 +623,19 @@ namespace HandlebarsDotNet.Test
             Assert.Equal(expected, actual1);
             Assert.Equal(expected, actual2);
         }
-        
+
+        // Issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/457
+        [Fact]
+        public void StringLength()
+        {
+            var handlebars = Handlebars.Create();
+            var render = handlebars.Compile("{{str.length}}");
+            object data = new { str = "string" };
+
+            var actual = render(data);
+            Assert.Equal("6", actual);
+        }
+
         // Issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/470
         [Theory]
         [ClassData(typeof(EscapeExpressionGenerator))]

--- a/source/Handlebars/ObjectDescriptors/ObjectDescriptorProvider.cs
+++ b/source/Handlebars/ObjectDescriptors/ObjectDescriptorProvider.cs
@@ -13,8 +13,6 @@ namespace HandlebarsDotNet.ObjectDescriptors
 {
     public sealed class ObjectDescriptorProvider : IObjectDescriptorProvider
     {
-        private static readonly Type StringType = typeof(string);
-        
         private readonly LookupSlim<Type, DeferredValue<Type, ChainSegment[]>, ReferenceEqualityComparer<Type>> _membersCache = new LookupSlim<Type, DeferredValue<Type, ChainSegment[]>, ReferenceEqualityComparer<Type>>(new ReferenceEqualityComparer<Type>());
         private readonly ReflectionMemberAccessor _reflectionMemberAccessor;
 
@@ -25,17 +23,11 @@ namespace HandlebarsDotNet.ObjectDescriptors
         
         public bool TryGetDescriptor(Type type, out ObjectDescriptor value)
         {
-            if (type == StringType)
-            {
-                value = ObjectDescriptor.Empty;
-                return false;
-            }
-            
             value = new ObjectDescriptor(
-                type, 
-                _reflectionMemberAccessor, 
-                GetProperties, 
-                self => new ObjectIterator(self), 
+                type,
+                _reflectionMemberAccessor,
+                GetProperties,
+                self => new ObjectIterator(self),
                 dependencies: _membersCache
             );
 


### PR DESCRIPTION
Includes:
- closes #457
- issue test case


First time contributing, my fix is to remove the following `if` check in order to return a normal `ObjectDescriptor` within the `ObjectDescriptorProvider.TryGetDescriptor(...)` method.

```csharp
// ObjectDescriptorProvider.cs
public bool TryGetDescriptor(Type type, out ObjectDescriptor value)
{
    if (type == StringType)
    {
        value = ObjectDescriptor.Empty;
        return false;
    }
    ...
}
```
I don't fully understand the reasoning behind this `if` check.
This `if` check was added in "*Introduce reactive helper registration, improve general performance*"  - commit: [9d52004](https://github.com/Handlebars-Net/Handlebars.Net/commit/9d52004d26321e6f9f367bc3f7eb276c0246ef04).


Anyway this PR removes this check, let me know if you don't think this is a good change or have any suggestions.