### PR TITLE
Fix collision handling in`FixedSizeDictionary`

### DIFF
--- a/source/Handlebars.Test/Collections/FixedSizeDictionaryTests.cs
+++ b/source/Handlebars.Test/Collections/FixedSizeDictionaryTests.cs
@@ -16,6 +16,31 @@ namespace HandlebarsDotNet.Test.Collections
         }
 
         [Fact]
+        public void AddOrReplace_Collisions()
+        {
+            var comparer = new CollisionsComparer(new Random().Next());
+            var dictionary = new FixedSizeDictionary<object, object, CollisionsComparer>(16, 7, comparer);
+            for (var i = 0; i < dictionary.Capacity; i++)
+            {
+                dictionary.AddOrReplace(new object(), new object(), out _);
+            }
+        }
+        
+        private readonly struct CollisionsComparer : IEqualityComparer<object>
+        {
+            private readonly int _hash;
+
+            public CollisionsComparer(int hash)
+            {
+                _hash = hash;
+            }
+            
+            public bool Equals(object x, object y) => false;
+
+            public int GetHashCode(object obj) => _hash;
+        }
+
+        [Fact]
         public void AddOrReplace()
         {
             var objects = new object[245];

--- a/source/Handlebars/Collections/FixedSizeDictionary.cs
+++ b/source/Handlebars/Collections/FixedSizeDictionary.cs
@@ -288,6 +288,7 @@ namespace HandlebarsDotNet.Collections
             
             ref var entryReference = ref _entries[entry.Index];
             entryIndex = entryReference.Index + 1;
+            var downstreamEntryIndex = entryIndex - 1;
 
             for (; entryIndex < _entries.Length; entryIndex++)
             {
@@ -301,7 +302,10 @@ namespace HandlebarsDotNet.Collections
                 return;
             }
 
-            entryIndex = (bucketIndex * _bucketMask) - 1;
+            // we've searched all entries in -> direction, now visiting in  <- direction
+            entryIndex = downstreamEntryIndex - 1;
+            // handling special case when `downstreamEntryIndex` can result into value >= _entries.Length
+            if (entryIndex >= _entries.Length) entryIndex = _entries.Length - 1;
             for (; entryIndex >= 0; entryIndex--)
             {
                 entry = _entries[entryIndex];


### PR DESCRIPTION
In rare cases (depended on `hashcode`) as part of searching for a suitable place in the array search started from index greater than array length.

Issues:
- closes #498 