### PR TITLE
Introduce `SharedEnvironment`

### DIFF
--- a/source/Handlebars.Test/Handlebars.Test.csproj
+++ b/source/Handlebars.Test/Handlebars.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">$(TargetFrameworks);net452;net46;net461;net472</TargetFrameworks>
     <ProjectGuid>6BA232A6-8C4D-4C7D-BD75-1844FE9774AF</ProjectGuid>
     <RootNamespace>HandlebarsDotNet.Test</RootNamespace>

--- a/source/Handlebars.Test/HandlebarsEnvGenerator.cs
+++ b/source/Handlebars.Test/HandlebarsEnvGenerator.cs
@@ -10,6 +10,7 @@ namespace HandlebarsDotNet.Test
         private readonly List<IHandlebars> _data = new()
         {
             Handlebars.Create(),
+            Handlebars.CreateSharedEnvironment(),
             Handlebars.Create(new HandlebarsConfiguration().Configure(o => o.Compatibility.RelaxedHelperNaming = true)),
             Handlebars.Create(new HandlebarsConfiguration().UseWarmUp(types =>
             {

--- a/source/Handlebars/EqualityComparers/PathInfoLight.PathInfoLightEqualityComparer.cs
+++ b/source/Handlebars/EqualityComparers/PathInfoLight.PathInfoLightEqualityComparer.cs
@@ -5,7 +5,7 @@ namespace HandlebarsDotNet
 {
     public readonly partial struct PathInfoLight
     {
-        internal sealed class PathInfoLightEqualityComparer : IEqualityComparer<PathInfoLight>
+        internal readonly struct PathInfoLightEqualityComparer : IEqualityComparer<PathInfoLight>
         {
             private readonly PathInfo.TrimmedPathEqualityComparer _comparer;
 

--- a/source/Handlebars/Handlebars.cs
+++ b/source/Handlebars/Handlebars.cs
@@ -24,8 +24,19 @@ namespace HandlebarsDotNet
             configuration = configuration ?? new HandlebarsConfiguration();
             return new HandlebarsEnvironment(configuration);
         }
-        
-        
+
+        /// <summary>
+        /// Creates shared Handlebars environment that is used to compile templates that share the same configuration
+        /// <para>Runtime only changes can be applied after object creation!</para>
+        /// </summary>
+        /// <param name="configuration"></param>
+        /// <returns></returns>
+        public static IHandlebars CreateSharedEnvironment(HandlebarsConfiguration configuration = null)
+        {
+            configuration ??= new HandlebarsConfiguration();
+            return new HandlebarsEnvironment(new HandlebarsConfigurationAdapter(configuration));
+        }
+
         /// <summary>
         /// Creates standalone instance of <see cref="Handlebars"/> environment
         /// </summary>

--- a/source/Handlebars/HandlebarsEnvironment.cs
+++ b/source/Handlebars/HandlebarsEnvironment.cs
@@ -4,7 +4,6 @@ using HandlebarsDotNet.Collections;
 using HandlebarsDotNet.Compiler;
 using HandlebarsDotNet.Decorators;
 using HandlebarsDotNet.Helpers;
-using HandlebarsDotNet.Helpers.BlockHelpers;
 using HandlebarsDotNet.IO;
 using HandlebarsDotNet.ObjectDescriptors;
 using HandlebarsDotNet.Runtime;
@@ -37,8 +36,11 @@ namespace HandlebarsDotNet
         internal HandlebarsEnvironment(ICompiledHandlebarsConfiguration configuration)
         {
             CompiledConfiguration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            Configuration = CompiledConfiguration.UnderlingConfiguration;
+            IsSharedEnvironment = true;
         }
-        
+
+        public bool IsSharedEnvironment { get; }
         public HandlebarsConfiguration Configuration { get; }
         internal ICompiledHandlebarsConfiguration CompiledConfiguration { get; }
         ICompiledHandlebarsConfiguration ICompiledHandlebars.CompiledConfiguration => CompiledConfiguration;
@@ -113,6 +115,12 @@ namespace HandlebarsDotNet
                     compiledView(encodedTextWriter, newBindingContext);
                 }
             };
+        }
+
+        public IHandlebars CreateSharedEnvironment()
+        {
+            var configuration = CompiledConfiguration ?? new HandlebarsConfigurationAdapter(Configuration);
+            return new HandlebarsEnvironment(configuration);
         }
 
         public HandlebarsTemplate<TextWriter, object, object> Compile(TextReader template)

--- a/source/Handlebars/IHandlebars.cs
+++ b/source/Handlebars/IHandlebars.cs
@@ -20,6 +20,14 @@ namespace HandlebarsDotNet
     public interface IHandlebars : IHelpersRegistry
     {
         /// <summary>
+        /// Creates shared Handlebars environment that is used to compile templates that share the same configuration
+        /// <para>Runtime only changes can be applied after object creation!</para>
+        /// </summary>
+        IHandlebars CreateSharedEnvironment();
+        
+        bool IsSharedEnvironment { get; }
+        
+        /// <summary>
         /// 
         /// </summary>
         /// <param name="template"></param>

--- a/source/Handlebars/PathInfoLight.cs
+++ b/source/Handlebars/PathInfoLight.cs
@@ -25,9 +25,9 @@ namespace HandlebarsDotNet
             _comparerTag = comparerTag;
         }
 
-        internal static IEqualityComparer<PathInfoLight> PlainPathComparer { get; } = new PathInfoLightEqualityComparer(false);
+        internal static PathInfoLightEqualityComparer PlainPathComparer { get; } = new PathInfoLightEqualityComparer(countParts: false, ignoreCase: true);
 
-        internal static IEqualityComparer<PathInfoLight> PlainPathWithPartsCountComparer { get; } = new PathInfoLightEqualityComparer();
+        internal static PathInfoLightEqualityComparer PlainPathWithPartsCountComparer { get; } = new PathInfoLightEqualityComparer(countParts: true, ignoreCase: true);
         
         /// <summary>
         /// Used for special handling of Relaxed Helper Names


### PR DESCRIPTION
Introduces `SharedEnvironment` to deal with big memory footprint when runtime has a lot of compiled templates. 

Issues:
- closes #513 