### PR TITLE
Fix 535 OutOfMemoryException

### DIFF
--- a/source/Handlebars.Test/IssueTests.cs
+++ b/source/Handlebars.Test/IssueTests.cs
@@ -723,5 +723,15 @@ namespace HandlebarsDotNet.Test
 
             Assert.Equal("abcd", templateOutput);
         }
+
+        // Issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/535
+        // Issue refers to invalid template causing OutOfMemoryException
+        [Fact]
+        public void UnrecognisedExpressionThrowsOutOfMemoryException()
+        {
+            var source = "{{Name | invalid}}";
+
+            Assert.Throws<HandlebarsCompilerException>(()=> Handlebars.Compile(source));
+        }
     }
 }

--- a/source/Handlebars/Compiler/Lexer/Parsers/BlockParamsParser.cs
+++ b/source/Handlebars/Compiler/Lexer/Parsers/BlockParamsParser.cs
@@ -23,7 +23,7 @@ namespace HandlebarsDotNet.Compiler.Lexer
                 
                 reader.Read();
             
-                while (reader.Peek() != '|')
+                while (reader.Peek() != '|' && reader.Peek() != -1)
                 {
                     buffer.Append((char) reader.Read());
                 }


### PR DESCRIPTION
https://github.com/Handlebars-Net/Handlebars.Net/issues/535

The following line currently throws an OutOfMemoryException for unrecognised expressions:
https://github.com/Handlebars-Net/Handlebars.Net/blob/01ad0e69e56331371f85a1c59c008d7ecfd06f78/source/Handlebars/Compiler/Lexer/Parsers/BlockParamsParser.cs#L28

This PR exits the while loop when reaching the end of the end of the string reader.

