### PR TITLE
Introduce PartialRecursionDepthLimit

### DIFF
--- a/source/Handlebars/BindingContext.cs
+++ b/source/Handlebars/BindingContext.cs
@@ -117,6 +117,8 @@ namespace HandlebarsDotNet
 
         internal TemplateDelegate PartialBlockTemplate { get; set; }
         
+        internal short PartialDepth { get; set; }
+        
         public object Value { get; set; }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/source/Handlebars/Configuration/HandlebarsConfiguration.cs
+++ b/source/Handlebars/Configuration/HandlebarsConfiguration.cs
@@ -59,6 +59,11 @@ namespace HandlebarsDotNet
         /// </summary>
         public IMissingPartialTemplateHandler MissingPartialTemplateHandler { get; set; }
         
+        /// <summary>
+        /// Maximum depth to recurse into partial templates when evaluating the template. Defaults to 100.
+        /// </summary>
+        public short PartialRecursionDepthLimit { get; set; } = 100;
+        
         /// <inheritdoc cref="IMemberAliasProvider"/>
         public IAppendOnlyList<IMemberAliasProvider> AliasProviders { get; } = new ObservableList<IMemberAliasProvider>();
 

--- a/source/Handlebars/Configuration/HandlebarsConfigurationAdapter.cs
+++ b/source/Handlebars/Configuration/HandlebarsConfigurationAdapter.cs
@@ -63,6 +63,7 @@ namespace HandlebarsDotNet
         public bool ThrowOnUnresolvedBindingExpression => UnderlingConfiguration.ThrowOnUnresolvedBindingExpression;
         public IPartialTemplateResolver PartialTemplateResolver => UnderlingConfiguration.PartialTemplateResolver;
         public IMissingPartialTemplateHandler MissingPartialTemplateHandler => UnderlingConfiguration.MissingPartialTemplateHandler;
+        public short PartialRecursionDepthLimit => UnderlingConfiguration.PartialRecursionDepthLimit;
         public Compatibility Compatibility => UnderlingConfiguration.Compatibility;
 
         public bool NoEscape => UnderlingConfiguration.NoEscape;

--- a/source/Handlebars/Configuration/ICompiledHandlebarsConfiguration.cs
+++ b/source/Handlebars/Configuration/ICompiledHandlebarsConfiguration.cs
@@ -36,6 +36,8 @@ namespace HandlebarsDotNet
         
         IMissingPartialTemplateHandler MissingPartialTemplateHandler { get; }
         
+        short PartialRecursionDepthLimit { get; }
+        
         IIndexed<PathInfoLight, Ref<IHelperDescriptor<HelperOptions>>> Helpers { get; }
         
         IIndexed<PathInfoLight, Ref<IHelperDescriptor<BlockHelperOptions>>> BlockHelpers { get; }

--- a/source/Handlebars/Pools/BindingContext.Pool.cs
+++ b/source/Handlebars/Pools/BindingContext.Pool.cs
@@ -33,6 +33,7 @@ namespace HandlebarsDotNet
                 context.Value = value;
                 context.ParentContext = parent;
                 context.PartialBlockTemplate = partialBlockTemplate;
+                context.PartialDepth = parent?.PartialDepth ?? 0;
 
                 context.Initialize();
 


### PR DESCRIPTION
When evaluating templates with partials, it is possible to recurse in the evaluation of those partials. This can be useful for dealing with tree like data, such as rendering a list of friends-of-friends-of-friends-of-etc....

The ability to recurse can lead to stack overflows. For example if a sufficiently deep tree is provided as input data, or more simply if the partial calls itself in an infinite loop. As a stack overflow terminates the process, this is not desirable behaviour as it is an unavoidable crash.

To resolve this a configurable PartialRecursionDepthLimit is introduced, defaulting to 100. Now when a template is evaluated a HandlebarsRuntimeException will be thrown if this limit is reached. This allows the caller to catch the exception and recover gracefully, rather than terminating the process.