### PR TITLE
Allow slashes properly within escape blocks

### DIFF
--- a/source/Handlebars.Test/PathInfoTests.cs
+++ b/source/Handlebars.Test/PathInfoTests.cs
@@ -50,6 +50,8 @@ namespace HandlebarsDotNet.Test
         [InlineData("a/[b.c].[b/c]/d", new [] {"a", "[b.c].[b/c]", "d"})]
         [InlineData("a/[b/c]/d", new [] {"a", "[b/c]", "d"})]
         [InlineData("a/[b.c/d]/e", new [] {"a", "[b.c/d]", "e"})]
+        [InlineData("a/[b.c/d/e/f]/e", new [] {"a", "[b.c/d/e/f]", "e"})]
+        [InlineData("a/[a//b/c.d/e]/e", new [] {"a", "[a//b/c.d/e]", "e"})]
         public void SlashPath(string input, string[] expected)
         {
             var pathInfo = PathInfo.Parse(input);

--- a/source/Handlebars.Test/PathInfoTests.cs
+++ b/source/Handlebars.Test/PathInfoTests.cs
@@ -52,6 +52,7 @@ namespace HandlebarsDotNet.Test
         [InlineData("a/[b.c/d]/e", new [] {"a", "[b.c/d]", "e"})]
         [InlineData("a/[b.c/d/e/f]/e", new [] {"a", "[b.c/d/e/f]", "e"})]
         [InlineData("a/[a//b/c.d/e]/e", new [] {"a", "[a//b/c.d/e]", "e"})]
+        [InlineData("a/[b/c/d].[e/f/g]/h", new [] {"a", "[b/c/d].[e/f/g]", "h"})]
         public void SlashPath(string input, string[] expected)
         {
             var pathInfo = PathInfo.Parse(input);

--- a/source/Handlebars/PathStructure/PathInfo.cs
+++ b/source/Handlebars/PathStructure/PathInfo.cs
@@ -173,7 +173,7 @@ namespace HandlebarsDotNet.PathStructure
                 if(Substring.LastIndexOf(segment, '[', out var startIndex) 
                    && !Substring.LastIndexOf(segment, ']', startIndex, out _))
                 {
-                    buffer.Append(in segment);
+                    if (!bufferHasOpenEscapeBlock) buffer.Append(in segment);
                     bufferHasOpenEscapeBlock = true;
                     continue;
                 }

--- a/source/Handlebars/PathStructure/PathInfo.cs
+++ b/source/Handlebars/PathStructure/PathInfo.cs
@@ -148,6 +148,7 @@ namespace HandlebarsDotNet.PathStructure
             var extendedEnumerator = ExtendedEnumerator<Substring>.Create(pathParts);
             using var container = StringBuilderPool.Shared.Use();
             var buffer = container.Value;
+            var bufferHasOpenEscapeBlock = false;
             
             while (extendedEnumerator.MoveNext())
             {
@@ -159,6 +160,7 @@ namespace HandlebarsDotNet.PathStructure
                     if(Substring.LastIndexOf(segment, ']', out var index) 
                        && !Substring.LastIndexOf(segment, '[', index, out _))
                     {
+                        bufferHasOpenEscapeBlock = false;
                         var chainSegment = GetPathChain(buffer.ToString());
                         if (chainSegment.Length > 1) isValidHelperLiteral = false;
 
@@ -172,6 +174,7 @@ namespace HandlebarsDotNet.PathStructure
                    && !Substring.LastIndexOf(segment, ']', startIndex, out _))
                 {
                     buffer.Append(in segment);
+                    bufferHasOpenEscapeBlock = true;
                     continue;
                 }
                 
@@ -192,7 +195,7 @@ namespace HandlebarsDotNet.PathStructure
 
                 if (chainSegments.Length > 1 && pathType != PathType.BlockHelper) isValidHelperLiteral = false;
 
-                segments.Add(new PathSegment(segment, chainSegments));
+                if (!bufferHasOpenEscapeBlock) segments.Add(new PathSegment(segment, chainSegments));
             }
 
             if (isValidHelperLiteral && segments.Count > 1) isValidHelperLiteral = false;


### PR DESCRIPTION
closes #566 

The path parsing currently doesn't work properly when there are embedded slashes within an ignore block.

This PR fixes this issue:
- No more exceptions thrown when using `//` within an escaped block
- Allowing multiple `/` to occur within an escape block without breakage

Before, the individual segments between slashes in addition to the entire escaped block were returned by PathInfo. Now, it returns just the latter, which is correct. All existing unit tests still pass and new tests were added to exercise the failing cases in #566.