### PR TITLE
Throw properly on open ignore block instead of crashing

### DIFF
--- a/source/Handlebars.Test/ExceptionTests.cs
+++ b/source/Handlebars.Test/ExceptionTests.cs
@@ -57,5 +57,14 @@ namespace HandlebarsDotNet.Test
                 Handlebars.Compile("{{#each enumerateMe}}test{{/if}}{{/each}}")(data);
             });
         }
+
+        [Fact]
+        public void TestNonClosingIgnoreBlockException()
+        {
+            Assert.Throws<HandlebarsParserException>(() =>
+            {
+                Handlebars.Compile("{{ [test }}")(new { });
+            });
+        }
    }
 }

--- a/source/Handlebars/Compiler/Lexer/Parsers/WordParser.cs
+++ b/source/Handlebars/Compiler/Lexer/Parsers/WordParser.cs
@@ -44,16 +44,7 @@ namespace HandlebarsDotNet.Compiler.Lexer
 
             while (true)
             {
-                if (isEscaped)
-                {
-                    var c = (char) reader.Read();
-                    if (c == ']') isEscaped = false;
-                    
-                    buffer.Append(c);
-                    continue;
-                }
-                
-                if (!inString)
+                if (!inString && !isEscaped)
                 {
                     var peek = (char) reader.Peek();
 
@@ -68,6 +59,15 @@ namespace HandlebarsDotNet.Compiler.Lexer
                 if (node == -1)
                 {
                     throw new HandlebarsParserException("Reached end of template before the expression was closed.", reader.GetContext());
+                }
+
+                if (isEscaped)
+                {
+                    var c = (char) node;
+                    if (c == ']') isEscaped = false;
+                    
+                    buffer.Append(c);
+                    continue;
                 }
 
                 if (node == '[' && !inString)


### PR DESCRIPTION
Closes #568 

Resolve the hang on compile when there is an open ignore block

Reshuffle the logic so that the throw check for end of template is done before trying to process the char