### PR TITLE
Update of TFM & dependency optimisation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches: [ master ]
- 
+
 jobs:
   build:
     name: Build
@@ -30,14 +30,14 @@ jobs:
         os: [ macos-latest, ubuntu-latest, windows-2019 ]
     steps:
       - uses: actions/checkout@master
-      - name: Setup dotnet 2.1
+      - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 2.1.x
-      - name: Setup dotnet 3.1
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.1.x
+          dotnet-version: |
+              2.1.x
+              3.1.x
+              5.0.x
+              6.0.x
       - name: Clean package cache as a temporary workaround for https://github.com/actions/setup-dotnet/issues/155
         working-directory: ./source
         run: dotnet clean -c Release && dotnet nuget locals all --clear
@@ -52,14 +52,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Setup dotnet 2.1
+      - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 2.1.x
-      - name: Setup dotnet 3.1
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.1.x
+          dotnet-version: |
+              2.1.x
+              3.1.x
+              5.0.x
+              6.0.x
       - uses: actions/setup-java@v4
         with:
           java-version: '21' # The JDK version to make available on the path.
@@ -97,7 +97,7 @@ jobs:
           .\.sonar\scanner\dotnet-sonarscanner begin /k:"Handlebars-Net_Handlebars.Net" /o:"handlebars-net" /d:sonar.login="${{ env.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="**/*.opencover.xml" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.coverage.exclusions="**/*.md;source/Handlebars.Benchmark/**/*.*" /d:sonar.cpd.exclusions="source/Handlebars/Iterators/**/*.*"
           dotnet build source/Handlebars.sln -c Release
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ env.SONAR_TOKEN }}"
-        
+
   benchmark:
     name: Run Benchmark.Net
     runs-on: ubuntu-latest
@@ -105,7 +105,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: |
+              2.1.x
+              3.1.x
+              5.0.x
+              6.0.x
       - name: Clean package cache as a temporary workaround for https://github.com/actions/setup-dotnet/issues/155
         working-directory: ./source
         run: dotnet clean -c Release && dotnet nuget locals all --clear
@@ -136,8 +140,8 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Benchmark
-          path: source/Handlebars.Benchmark/BenchmarkDotNet.Artifacts/results/      
-        
+          path: source/Handlebars.Benchmark/BenchmarkDotNet.Artifacts/results/
+
   update_release_draft:
     name: Release Drafter
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
           dotnet-version: |
               2.1.x
               3.1.x
-              5.0.x
               6.0.x
       - name: Clean package cache as a temporary workaround for https://github.com/actions/setup-dotnet/issues/155
         working-directory: ./source
@@ -58,7 +57,6 @@ jobs:
           dotnet-version: |
               2.1.x
               3.1.x
-              5.0.x
               6.0.x
       - uses: actions/setup-java@v4
         with:
@@ -108,7 +106,6 @@ jobs:
           dotnet-version: |
               2.1.x
               3.1.x
-              5.0.x
               6.0.x
       - name: Clean package cache as a temporary workaround for https://github.com/actions/setup-dotnet/issues/155
         working-directory: ./source

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,6 @@ jobs:
           dotnet-version: |
               2.1.x
               3.1.x
-              5.0.x
               6.0.x
       - name: Clean package cache as a temporary workaround for https://github.com/actions/setup-dotnet/issues/155
         working-directory: ./source
@@ -40,7 +39,6 @@ jobs:
           dotnet-version: |
               2.1.x
               3.1.x
-              5.0.x
               6.0.x
       - name: Clean package cache as a temporary workaround for https://github.com/actions/setup-dotnet/issues/155
         working-directory: ./source
@@ -62,7 +60,6 @@ jobs:
           dotnet-version: |
               2.1.x
               3.1.x
-              5.0.x
               6.0.x
       - uses: actions/setup-java@v4
         with:
@@ -112,7 +109,6 @@ jobs:
           dotnet-version: |
               2.1.x
               3.1.x
-              5.0.x
               6.0.x
       - name: Clean package cache as a temporary workaround for https://github.com/actions/setup-dotnet/issues/155
         working-directory: ./source

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,21 +6,25 @@ on:
 
 jobs:
   build:
-    name: Build 
+    name: Build
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@master
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: |
+              2.1.x
+              3.1.x
+              5.0.x
+              6.0.x
       - name: Clean package cache as a temporary workaround for https://github.com/actions/setup-dotnet/issues/155
         working-directory: ./source
         run: dotnet clean -c Release && dotnet nuget locals all --clear
       - name: Build
         working-directory: ./source
         run: dotnet build -c Release
-        
+
   test:
     name: Tests on ${{ matrix.os }}
     needs: [ build ]
@@ -30,36 +34,36 @@ jobs:
         os: [ macos-latest, ubuntu-latest, windows-2019 ]
     steps:
       - uses: actions/checkout@master
-      - name: Setup dotnet 2.1
+      - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 2.1.x
-      - name: Setup dotnet 3.1
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.1.x
+          dotnet-version: |
+              2.1.x
+              3.1.x
+              5.0.x
+              6.0.x
       - name: Clean package cache as a temporary workaround for https://github.com/actions/setup-dotnet/issues/155
         working-directory: ./source
         run: dotnet clean -c Release && dotnet nuget locals all --clear
       - name: Test
         working-directory: ./source
         run: dotnet test --logger:trx --logger:GitHubActions
-        
+
   sonar-pr:
     name: SonarCloud
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v2 
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Setup dotnet 2.1
+      - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 2.1.x
-      - name: Setup dotnet 3.1
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.1.x
+          dotnet-version: |
+              2.1.x
+              3.1.x
+              5.0.x
+              6.0.x
       - uses: actions/setup-java@v4
         with:
           java-version: '21' # The JDK version to make available on the path.
@@ -105,7 +109,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: |
+              2.1.x
+              3.1.x
+              5.0.x
+              6.0.x
       - name: Clean package cache as a temporary workaround for https://github.com/actions/setup-dotnet/issues/155
         working-directory: ./source
         run: dotnet clean -c Release && dotnet nuget locals all --clear
@@ -132,7 +140,7 @@ jobs:
           comment-on-alert: true
           fail-on-alert: false
           alert-comment-cc-users: '@zjklee'
-          
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
           dotnet-version: |
               2.1.x
               3.1.x
-              5.0.x
               6.0.x
 
       - name: Clean package cache as a temporary workaround for https://github.com/actions/setup-dotnet/issues/155

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,11 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: |
+              2.1.x
+              3.1.x
+              5.0.x
+              6.0.x
 
       - name: Clean package cache as a temporary workaround for https://github.com/actions/setup-dotnet/issues/155
         working-directory: ./source

--- a/source/Handlebars.Test/DynamicTests.cs
+++ b/source/Handlebars.Test/DynamicTests.cs
@@ -22,7 +22,7 @@ namespace HandlebarsDotNet.Test
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
-        
+
         [Fact]
 		public void DynamicObjectBasicTest()
         {
@@ -36,7 +36,7 @@ namespace HandlebarsDotNet.Test
 
             Assert.Equal("Foo: 1\nBar: hello world", output);
         }
-        
+
         [Fact]
         public void DynamicObjectBasicIterationTest()
         {
@@ -106,7 +106,7 @@ namespace HandlebarsDotNet.Test
 
             Assert.Equal("Key1Val1Key2Val2", output);
         }
-        
+
         [Theory]
         [ClassData(typeof(EnvGenerator))]
         public void JsonTestArrayCount(IHandlebars handlebars)
@@ -121,7 +121,7 @@ namespace HandlebarsDotNet.Test
 
 	        Assert.Equal("2", output);
         }
-        
+
         [Theory]
         [ClassData(typeof(EnvGenerator))]
         public void JsonTestObjects(IHandlebars handlebars){
@@ -150,7 +150,7 @@ namespace HandlebarsDotNet.Test
 
             Assert.Equal("", output);
         }
-        
+
         [Theory]
         [ClassData(typeof(EnvGenerator))]
         public void WithParentIndexJsonNet(IHandlebars handlebars)
@@ -174,7 +174,7 @@ namespace HandlebarsDotNet.Test
                         {{/each}}
                     {{/each}}    
                 {{/each}}";
-            
+
             var template = handlebars.Compile( source );
             var data = new
                 {
@@ -281,13 +281,13 @@ namespace HandlebarsDotNet.Test
                                     index=[1:1:1]
                                     first=[False:False:False]
                                     last=[True:True:True]";
-            
+
             Func<string, string> makeFlat = text => text.Replace( " ", "" ).Replace( "\n", "" ).Replace( "\r", "" );
 
             Assert.Equal( makeFlat( expected ), makeFlat( result ) );
         }
 
-#if !netstandard
+#if NET452 || NET46 || NET461 || NET472
 
         [Fact]
         public void SystemJsonTestArrays()

--- a/source/Handlebars.Test/Handlebars.Test.csproj
+++ b/source/Handlebars.Test/Handlebars.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5;net6</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">$(TargetFrameworks);net452;net46;net461;net472</TargetFrameworks>
     <ProjectGuid>6BA232A6-8C4D-4C7D-BD75-1844FE9774AF</ProjectGuid>
     <RootNamespace>HandlebarsDotNet.Test</RootNamespace>

--- a/source/Handlebars.Test/Handlebars.Test.csproj
+++ b/source/Handlebars.Test/Handlebars.Test.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5;net6</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">$(TargetFrameworks);net452;net46;net461;net472</TargetFrameworks>
     <ProjectGuid>6BA232A6-8C4D-4C7D-BD75-1844FE9774AF</ProjectGuid>
     <RootNamespace>HandlebarsDotNet.Test</RootNamespace>
@@ -10,7 +10,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <NoWarn>0618;1701</NoWarn>
   </PropertyGroup>
@@ -27,13 +27,19 @@
   <PropertyGroup Condition="'$(TargetFramework)'=='net452'">
     <DefineConstants>$(DefineConstants);netFramework</DefineConstants>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
     <DefineConstants>$(DefineConstants);netcoreapp;netstandard</DefineConstants>
   </PropertyGroup>
-   
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);netcoreapp;netstandard</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net5'">
+    <DefineConstants>$(DefineConstants);netcoreapp;netstandard;net</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='net6'">
+    <DefineConstants>$(DefineConstants);netcoreapp;netstandard;net</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -52,7 +58,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
-  
+
 
   <ItemGroup Condition="'$(TargetFramework)'=='net46' or '$(TargetFramework)'=='net461' or '$(TargetFramework)'=='net472' or '$(TargetFramework)'=='net452'">
     <PackageReference Include="CsQuery" Version="1.3.4" />
@@ -60,18 +66,18 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
   </ItemGroup>
-  
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1' or '$(TargetFramework)'=='netcoreapp2.1'">
+
+  <ItemGroup Condition="'$(TargetFramework)'!='net46' and '$(TargetFramework)'!='net461' and '$(TargetFramework)'!='net472' and '$(TargetFramework)'!='net452'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
     <PackageReference Include="CsQuery.NetStandard" Version="1.3.6.1" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Content Include="ViewEngine\**\*.hbs" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/source/Handlebars.Test/Handlebars.Test.csproj
+++ b/source/Handlebars.Test/Handlebars.Test.csproj
@@ -9,37 +9,7 @@
     <SignAssembly>false</SignAssembly>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <NoWarn>0618;1701</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)'=='net472'">
-    <DefineConstants>$(DefineConstants);netFramework</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net461'">
-    <DefineConstants>$(DefineConstants);netFramework</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net46'">
-    <DefineConstants>$(DefineConstants);netFramework</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net452'">
-    <DefineConstants>$(DefineConstants);netFramework</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
-    <DefineConstants>$(DefineConstants);netcoreapp;netstandard</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-    <DefineConstants>$(DefineConstants);netcoreapp;netstandard</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)'=='net5'">
-    <DefineConstants>$(DefineConstants);netcoreapp;netstandard;net</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net6'">
-    <DefineConstants>$(DefineConstants);netcoreapp;netstandard;net</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Handlebars/Collections/ImmutableStack.cs
+++ b/source/Handlebars/Collections/ImmutableStack.cs
@@ -4,19 +4,19 @@ using HandlebarsDotNet.Pools;
 
 namespace HandlebarsDotNet.Collections
 {
-#if NET451 || NET452
+#if NET451
     [Serializable]
 #endif
     internal readonly struct ImmutableStack<T>
     {
         private readonly Node _container;
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private ImmutableStack(T value, Node parent)
             :this(Node.Create(value, parent))
         {
         }
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private ImmutableStack(Node container) => _container = container;
 
@@ -26,8 +26,8 @@ namespace HandlebarsDotNet.Collections
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T Peek()
         {
-            return _container == null 
-                ? default 
+            return _container == null
+                ? default
                 : _container.Value;
         }
 
@@ -39,20 +39,20 @@ namespace HandlebarsDotNet.Collections
                 value = default;
                 return this;
             }
-            
+
             value = _container.Value;
             var parent = _container.Parent;
             _container.Dispose();
             return new ImmutableStack<T>(parent);
         }
-        
-#if NET451 || NET452
+
+#if NET451
         [Serializable]
 #endif
         private sealed class Node : IDisposable
         {
             private static readonly InternalObjectPool<Node, Policy> Pool = new InternalObjectPool<Node, Policy>(new Policy());
-            
+
             public Node Parent;
             public T Value;
 
@@ -63,9 +63,9 @@ namespace HandlebarsDotNet.Collections
                 item.Parent = parent;
                 return item;
             }
-            
+
             private Node() { }
-            
+
             private struct Policy : IInternalObjectPoolPolicy<Node>
             {
                 public Node Create() => new Node();

--- a/source/Handlebars/Handlebars.csproj
+++ b/source/Handlebars/Handlebars.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Handlebars</AssemblyName>
     <ProjectGuid>9822C7B8-7E51-42BC-9A49-72A10491B202</ProjectGuid>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;net5;net6</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;net6</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net451;net452;net46</TargetFrameworks>
     <Version>2.0.0</Version>
     <RootNamespace>HandlebarsDotNet</RootNamespace>

--- a/source/Handlebars/Handlebars.csproj
+++ b/source/Handlebars/Handlebars.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Handlebars</AssemblyName>
     <ProjectGuid>9822C7B8-7E51-42BC-9A49-72A10491B202</ProjectGuid>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;net5;net6</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net451;net452;net46</TargetFrameworks>
     <Version>2.0.0</Version>
     <RootNamespace>HandlebarsDotNet</RootNamespace>
@@ -53,7 +53,7 @@
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)'=='net451' or '$(TargetFramework)'=='net452' or '$(TargetFramework)'=='net46'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
@@ -69,20 +69,13 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.1'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='netstandard2.1'">
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="ExpressionShortcuts" Version="1.0.4.39" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/source/Handlebars/Handlebars.csproj
+++ b/source/Handlebars/Handlebars.csproj
@@ -8,25 +8,6 @@
     <Version>2.0.0</Version>
     <RootNamespace>HandlebarsDotNet</RootNamespace>
     <SignAssembly Condition="'$(ShouldSignAssembly)' == 'true'">true</SignAssembly>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
-    <DefineConstants>$(DefineConstants);netstandard;netstandard1_3</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-    <DefineConstants>$(DefineConstants);netstandard</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net451'">
-    <DefineConstants>$(DefineConstants);NET451</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net452'">
-    <DefineConstants>$(DefineConstants);NET452</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net46'">
-    <DefineConstants>$(DefineConstants);NET46</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <Authors>Rex Morgan</Authors>
     <Copyright>Copyright © 2014-2020 Rex Morgan</Copyright>
     <Description>Blistering-fast Handlebars.js templates in your .NET application.</Description>

--- a/source/Handlebars/Handlebars.csproj
+++ b/source/Handlebars/Handlebars.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Handlebars</AssemblyName>
     <ProjectGuid>9822C7B8-7E51-42BC-9A49-72A10491B202</ProjectGuid>
     <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;net6</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net451;net452;net46</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net451</TargetFrameworks>
     <Version>2.0.0</Version>
     <RootNamespace>HandlebarsDotNet</RootNamespace>
     <SignAssembly Condition="'$(ShouldSignAssembly)' == 'true'">true</SignAssembly>
@@ -35,7 +35,7 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net451' or '$(TargetFramework)'=='net452' or '$(TargetFramework)'=='net46'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net451'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
@@ -46,7 +46,7 @@
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net451' or '$(TargetFramework)'=='net452' or '$(TargetFramework)'=='net46'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net451'">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/source/Handlebars/IO/EncodedTextWriter.cs
+++ b/source/Handlebars/IO/EncodedTextWriter.cs
@@ -20,24 +20,24 @@ namespace HandlebarsDotNet
 		{
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			get => !_encoder.Enabled;
-			
+
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			set => _encoder.Enabled = !value;
 		}
-		
+
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public EncodedTextWriter(
 			TextWriter writer,
-			ITextEncoder encoder, 
-			IFormatterProvider formatterProvider, 
+			ITextEncoder encoder,
+			IFormatterProvider formatterProvider,
 			bool suppressEncoding = false)
 		{
 			UnderlyingWriter = writer;
 			_formatterProvider = formatterProvider;
-			_encoder = encoder != null 
-				? TextEncoderWrapper.Create(encoder) 
+			_encoder = encoder != null
+				? TextEncoderWrapper.Create(encoder)
 				: TextEncoderWrapper.Null;
-			
+
 			SuppressEncoding = suppressEncoding;
 		}
 
@@ -52,7 +52,7 @@ namespace HandlebarsDotNet
 				_encoder.Encode(value, UnderlyingWriter);
 				return;
 			}
-			
+
 			UnderlyingWriter.Write(value);
 		}
 
@@ -70,7 +70,7 @@ namespace HandlebarsDotNet
 				UnderlyingWriter.Write(value[i]);
 			}
 		}
-		
+
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public void Write(Substring value, bool encode = true)
 		{
@@ -85,7 +85,7 @@ namespace HandlebarsDotNet
 				UnderlyingWriter.Write(value[i]);
 			}
 		}
-		
+
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public void Write<T>(T value, bool encode) where T: IEnumerator<char>
 		{
@@ -100,7 +100,7 @@ namespace HandlebarsDotNet
 				UnderlyingWriter.Write(value.Current);
 			}
 		}
-		
+
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public void Write(string value) => Write(value, true);
 
@@ -119,26 +119,26 @@ namespace HandlebarsDotNet
 			switch (value)
 			{
 				case null:
-				case string v when string.IsNullOrEmpty(v): 
+				case string v when string.IsNullOrEmpty(v):
 				case StringBuilder st when st.Length == 0:
 				case Substring substring when substring.Length == 0:
 					return;
-				
+
 				case string v: Write(v, true); return;
 				case StringBuilder v: Write(v, true); return;
-				case Substring v: Write(v, true); return; 
-				
+				case Substring v: Write(v, true); return;
+
 				default:
 					WriteFormatted(value);
 					return;
 			}
 		}
-		
+
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		private void WriteFormatted<T>(T value)
 		{
 			var type = typeof(T);
-#if netstandard1_3
+#if NETSTANDARD1_3
 			if (type.GetTypeInfo().IsClass) type = value.GetType();
 #else
 			if (type.IsClass) type = value.GetType();
@@ -155,11 +155,11 @@ namespace HandlebarsDotNet
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			get => UnderlyingWriter.Encoding;
 		}
-		
+
 		public void Dispose() => _encoder.Dispose();
-		
+
 		public override string ToString() => UnderlyingWriter.ToString();
-		
+
 		private static class Throw
 		{
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/source/Handlebars/Polyfills/AsyncLocal.cs
+++ b/source/Handlebars/Polyfills/AsyncLocal.cs
@@ -1,4 +1,4 @@
-#if NET451 || NET452
+#if NET451
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.Remoting.Messaging;
@@ -8,12 +8,12 @@ namespace HandlebarsDotNet.Polyfills
     public sealed class AsyncLocal<T>
     {
         private const string Slot = "__AsyncLocalSlot";
-        
+
         public T Value
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => CallContext.LogicalGetData(Slot) is Container container 
-                ? container.Value 
+            get => CallContext.LogicalGetData(Slot) is Container container
+                ? container.Value
                 : default;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
By adjusting the TFM'S we have been able to produce a package with no dependencies on the latest frameworks hence an optimised dependency graph.

The following frameworks have been added:
- Net 6

The following frameworks even though requested was not added:
- Net 5

The following frameworks were removed:
- Net 4.5.2
- Net 4.6

Closes: #573
Closes: #415