### PR TITLE
WeakReference garbage collection

### DIFF
--- a/source/Handlebars.Test/Collections/WeakCollectionTests.cs
+++ b/source/Handlebars.Test/Collections/WeakCollectionTests.cs
@@ -77,6 +77,41 @@ namespace HandlebarsDotNet.Test.Collections
             Assert.Equal(2, _collection.Count());
         }
         
+        // Reproduces the WeakCollection growth described in PR #604.
+        // WeakCollection.Add() only resets _firstAvailableIndex during Remove() or
+        // enumeration. In the static Handlebars.Compile() path each compilation
+        // registers new FormatterProvider/ObjectDescriptorFactory observers via Add()
+        // but never enumerates the collection. After GC those observer slots become
+        // dead WeakReferences, but _firstAvailableIndex is already past them, so
+        // every subsequent Add() scans to the end and appends — O(N²) total work.
+        [Fact]
+        public void BucketInCollectionReused_WithoutRequiringEnumeration()
+        {
+            CallInItsOwnScope(() =>
+            {
+                _collection.Add(new object());
+                _collection.Add(new object());
+                _collection.Add(new object());
+            });
+
+            GC.Collect();
+
+            // Dead slots must be reusable without first enumerating the collection.
+            // Bug:  _firstAvailableIndex == 3; Add() starts scanning there, finds
+            //       nothing before the end, and appends → Size grows to 5.
+            // Fix:  Add() resets to scan from 0 when it reaches the list end,
+            //       finds dead slots at [0..2], and reuses them → Size stays at 3.
+            var _2 = new object();
+            var _3 = new object();
+            _collection.Add(_2);
+            _collection.Add(_3);
+
+            Assert.Equal(3, _collection.Size);
+            Assert.Equal(2, _collection.Count());
+            GC.KeepAlive(_2);
+            GC.KeepAlive(_3);
+        }
+
         private static void CallInItsOwnScope(Action scope) => scope();
     }
 }

--- a/source/Handlebars/Collections/DictionarySlim.cs
+++ b/source/Handlebars/Collections/DictionarySlim.cs
@@ -183,7 +183,10 @@ namespace HandlebarsDotNet.Collections
                 (uint)i < (uint)entries.Length; i = entries[i].Next)
             {
                 if (_comparer.Equals(key, entries[i].Key))
+                {
                     entries[i].Value = value;
+                    return;
+                }
                 if (collisionCount == entries.Length)
                 {
                     // The chain of entries forms a loop; which means a concurrent update has happened.

--- a/source/Handlebars/Collections/WeakCollection.cs
+++ b/source/Handlebars/Collections/WeakCollection.cs
@@ -13,6 +13,8 @@ namespace HandlebarsDotNet.Collections
         
         public void Add(T value)
         {
+            // Need a way to reset _firstAvailableIndex periodically
+
             for (var index = _firstAvailableIndex; index < _store.Count; index++)
             {
                 if (_store[index] == null)

--- a/source/Handlebars/Collections/WeakCollection.cs
+++ b/source/Handlebars/Collections/WeakCollection.cs
@@ -13,8 +13,6 @@ namespace HandlebarsDotNet.Collections
         
         public void Add(T value)
         {
-            // Need a way to reset _firstAvailableIndex periodically
-
             for (var index = _firstAvailableIndex; index < _store.Count; index++)
             {
                 if (_store[index] == null)
@@ -31,9 +29,13 @@ namespace HandlebarsDotNet.Collections
                     return;
                 }
             }
-            
+
             _store.Add(new WeakReference<T>(value));
-            _firstAvailableIndex = _store.Count;
+            // Reset to 0 so the next Add() scans the full list and can reclaim any slots
+            // that became dead (GC-collected) since the last full pass. Without this reset,
+            // _firstAvailableIndex stays pinned at _store.Count after every append, dead
+            // slots are never reused, and the WeakReference/GC-handle count grows without bound.
+            _firstAvailableIndex = 0;
         }
         
         public void Remove(T value)

--- a/source/Handlebars/Pools/BindingContext.Pool.cs
+++ b/source/Handlebars/Pools/BindingContext.Pool.cs
@@ -46,6 +46,8 @@ namespace HandlebarsDotNet
 
                 public bool Return(BindingContext item)
                 {
+                    item.Configuration = null;
+
                     item.Root = null;
                     item.Value = null;
                     item.ParentContext = null;


### PR DESCRIPTION
While updating Handlebars.Net from 1.x to 2.1.6, I have noticed that GC Handler count increases significantly with every compiled template. GC Handlers are associated with WeakReference objects which were introduced in https://github.com/Handlebars-Net/Handlebars.Net/pull/456.

I discovered a couple of issues while investigating the GC Handlers increase.

My app complies templates using the static method `Handlebars.Compile()`.

### Before the Update
<img width="1722" height="930" alt="image" src="https://github.com/user-attachments/assets/55cbdcf9-669e-40e9-80ed-c265fa96de42" />

### After the Update
<img width="1727" height="932" alt="image" src="https://github.com/user-attachments/assets/430d8f78-49f2-4a9d-99e0-fffbbeb835b8" />
