### PR TITLE
Allow empty partial-block

### DIFF
--- a/source/Handlebars.Test/InlinePartialTests.cs
+++ b/source/Handlebars.Test/InlinePartialTests.cs
@@ -264,6 +264,18 @@ namespace HandlebarsDotNet.Test
 
             var result2 = template(data);
             Assert.Equal("Hello, Pete Jones!", result2);
+            
+            source = "Hello, {{#>personInline}}{{/personInline}}!";
+            template = Handlebars.Compile(source);
+
+            var result3 = template(data);
+            Assert.Equal("Hello, !", result3);
+
+            source = "{{#*inline \"personInline\"}}{{firstName}} {{lastName}}{{/inline}}" + source;
+            template = Handlebars.Compile(source);
+
+            var result4 = template(data);
+            Assert.Equal("Hello, Pete Jones!", result4);
         }
 
         [Fact]
@@ -412,6 +424,42 @@ namespace HandlebarsDotNet.Test
             while (ex.InnerException != null)
                 ex = Assert.IsType<HandlebarsRuntimeException>(ex.InnerException);
             Assert.Equal("Runtime error while rendering partial 'list', exceeded recursion depth limit of 100", ex.Message);
+        }
+
+        [Fact]
+        public void BlockInlinePartialWithInlinePartials()
+        {
+            string partialSource = "{{#*inline \"greeting\"}}{{#>salutation}}Dear{{/salutation}} {{#>name}}{{firstName}} {{lastName}}{{/name}}{{/inline}}";
+
+            var data = new
+            {
+                firstName = "Pete",
+                lastName = "Jones"
+            };
+
+            string source = partialSource + "{{#>greeting}}{{/greeting}}";
+            var template = Handlebars.Compile(source);
+
+            var result1 = template(data);
+            Assert.Equal("Dear Pete Jones", result1);
+
+            source = partialSource + "{{#>greeting}}{{#*inline \"salutation\"}}Hello{{/inline}}{{/greeting}}";
+            template = Handlebars.Compile(source);
+
+            var result2 = template(data);
+            Assert.Equal("Hello Pete Jones", result2);
+            
+            source = partialSource + "{{#>greeting}}{{#*inline \"name\"}}Mr. {{lastName}}{{/inline}}{{/greeting}}";
+            template = Handlebars.Compile(source);
+
+            var result3 = template(data);
+            Assert.Equal("Dear Mr. Jones", result3);
+
+            source = partialSource + "{{#>greeting}}{{#*inline \"salutation\"}}Hello{{/inline}}{{#*inline \"name\"}}{{firstName}}{{/inline}}{{/greeting}}";
+            template = Handlebars.Compile(source);
+
+            var result4 = template(data);
+            Assert.Equal("Hello Pete", result4);
         }
     }
 }

--- a/source/Handlebars.Test/IssueTests.cs
+++ b/source/Handlebars.Test/IssueTests.cs
@@ -1049,15 +1049,22 @@ namespace HandlebarsDotNet.Test
         {
             var handlebars = Handlebars.Create();
             handlebars.RegisterTemplate("myPartial",
-                @"Conditional:{{#if @partial-block}} {{> @partial-block}}{{/if}}
-Plain: {{> @partial-block}}
-Block:{{#> @partial-block }}{{/@partial-block}}");
+                """
+                Conditional: {{#if @partial-block}}{{> @partial-block}}{{/if}}
+                Plain: {{> @partial-block}}
+                Block with empty fallback: {{#> @partial-block }}{{/@partial-block}}
+                Block with non-empty fallback: {{#> @partial-block }}...{{/@partial-block}}
+                """);
 
             var render = handlebars.Compile("{{#> myPartial}}Block content{{/myPartial}}");
             var actual = render(new { });
-            Assert.Contains("Conditional: Block content", actual);
-            Assert.Contains("Plain: Block content", actual);
-            Assert.Contains("Block:Block content", actual);
+            Assert.Equal("""
+                         Conditional: Block content
+                         Plain: Block content
+                         Block with empty fallback: Block content
+                         Block with non-empty fallback: Block content
+                         """.ReplaceLineEndings("\n"),
+                actual);
         }
       
         // Issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/458

--- a/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/PartialBlockAccumulatorContext.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/PartialBlockAccumulatorContext.cs
@@ -24,7 +24,12 @@ namespace HandlebarsDotNet.Compiler
 
         public override Expression GetAccumulatedBlock()
         {
-            var fallback = _body.Count == 0 ? null : _body.Count == 1 ? _body.First() : Expression.Block(_body);
+            var fallback = _body.Count switch
+            {
+                0 => Expression.Empty(),
+                1 => _body[0],
+                _ => Expression.Block(_body)
+            };
             return HandlebarsExpression.Partial(_startingNode.PartialName, _startingNode.Argument, fallback);
         }
 

--- a/source/Handlebars/Compiler/Lexer/Converter/WhitespaceRemover.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/WhitespaceRemover.cs
@@ -71,6 +71,7 @@ namespace HandlebarsDotNet.Compiler
                         partialExpr.PartialName,
                         partialExpr.Argument,
                         partialExpr.Fallback,
+                        partialExpr.IsBlock,
                         indent);
                     list[index] = HandlebarsExpression.Statement(
                         indentedPartial,

--- a/source/Handlebars/Compiler/Structure/HandlebarsExpression.cs
+++ b/source/Handlebars/Compiler/Structure/HandlebarsExpression.cs
@@ -94,17 +94,17 @@ namespace HandlebarsDotNet.Compiler
 
         public static PartialExpression Partial(Expression partialName, Expression argument)
         {
-            return new PartialExpression(partialName, argument, null);
+            return new PartialExpression(partialName, argument, null, false);
         }
 
         public static PartialExpression Partial(Expression partialName, Expression argument, Expression fallback)
         {
-            return new PartialExpression(partialName, argument, fallback);
+            return new PartialExpression(partialName, argument, fallback, true);
         }
 
-        public static PartialExpression Partial(Expression partialName, Expression argument, Expression fallback, string indent)
+        public static PartialExpression Partial(Expression partialName, Expression argument, Expression fallback, bool isBlock, string indent)
         {
-            return new PartialExpression(partialName, argument, fallback, indent);
+            return new PartialExpression(partialName, argument, fallback, isBlock, indent);
         }
 
         public static BoolishExpression Boolish(Expression condition, HashParametersExpression hashParameters)

--- a/source/Handlebars/Compiler/Structure/PartialExpression.cs
+++ b/source/Handlebars/Compiler/Structure/PartialExpression.cs
@@ -4,11 +4,12 @@ namespace HandlebarsDotNet.Compiler
 {
     internal class PartialExpression : HandlebarsExpression
     {
-        public PartialExpression(Expression partialName, Expression argument, Expression fallback, string indent = null)
+        public PartialExpression(Expression partialName, Expression argument, Expression fallback, bool isBlock = false, string indent = null)
         {
             PartialName = partialName;
             Argument = argument;
             Fallback = fallback;
+            IsBlock = isBlock;
             Indent = indent;
         }
 
@@ -19,6 +20,8 @@ namespace HandlebarsDotNet.Compiler
         public Expression Argument { get; }
 
         public Expression Fallback { get; }
+
+        public bool IsBlock { get; }
 
         /// <summary>
         /// The whitespace that preceded the partial tag on its line.

--- a/source/Handlebars/Compiler/Translation/Expression/HandlebarsExpressionVisitor.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/HandlebarsExpressionVisitor.cs
@@ -105,7 +105,7 @@ namespace HandlebarsDotNet.Compiler
             if (partialName != pex.PartialName
                 || argument != pex.Argument)
             {
-                return HandlebarsExpression.Partial(partialName, argument, pex.Fallback);
+                return HandlebarsExpression.Partial(partialName, argument, pex.Fallback, pex.IsBlock, pex.Indent);
             }
             return pex;
         }

--- a/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
@@ -58,12 +58,13 @@ namespace HandlebarsDotNet.Compiler
                 var partialNameObj = Arg<object>(pex.PartialName);
                 var partialName = Call(() => ToPartialName(partialNameObj));
                 var configuration = Arg(CompilationContext.Configuration);
+                var isBlock = Arg(pex.IsBlock);
                 var indent = Arg(pex.Indent);
                 var templateDelegate = FunctionBuilder.Compile(
                     new []
                     {
                         Call(() =>
-                            InvokePartialWithFallback(partialName, bindingContext, writer, (ICompiledHandlebarsConfiguration) configuration, indent) // NOSONAR S1944 — ExpressionShortcuts operator; not a runtime hierarchy cast
+                            InvokePartialWithFallback(partialName, bindingContext, writer, (ICompiledHandlebarsConfiguration) configuration, isBlock, indent) // NOSONAR S1944 — ExpressionShortcuts operator; not a runtime hierarchy cast
                         ).Expression
                     },
                     CompilationContext,
@@ -92,10 +93,11 @@ namespace HandlebarsDotNet.Compiler
                 var partialNameObj = Arg<object>(pex.PartialName);
                 var partialName = Call(() => ToPartialName(partialNameObj));
                 var configuration = Arg(CompilationContext.Configuration);
+                var isBlock = Arg(pex.IsBlock);
                 var indent = Arg(pex.Indent);
 
                 return Call(() =>
-                    InvokePartialWithFallback(partialName, bindingContext, writer, (ICompiledHandlebarsConfiguration) configuration, indent)
+                    InvokePartialWithFallback(partialName, bindingContext, writer, (ICompiledHandlebarsConfiguration) configuration, isBlock, indent)
                 );
             }
         }
@@ -105,10 +107,11 @@ namespace HandlebarsDotNet.Compiler
             BindingContext context,
             EncodedTextWriter writer,
             ICompiledHandlebarsConfiguration configuration,
-            string indent = null)
+            bool block,
+            string indent)
         {
             partialName = partialName != null ? ChainSegment.Create(partialName).TrimmedValue : null;
-            if (InvokePartial(partialName, context, writer, configuration, indent)) return;
+            if (InvokePartial(partialName, context, writer, configuration, block, indent)) return;
             if (context.PartialBlockTemplate == null)
             {
                 if (configuration.MissingPartialTemplateHandler == null)
@@ -173,16 +176,24 @@ namespace HandlebarsDotNet.Compiler
             BindingContext context,
             EncodedTextWriter writer,
             ICompiledHandlebarsConfiguration configuration,
-            string indent = null)
+            bool block,
+            string indent)
         {
             if (partialName.Equals(SpecialPartialBlockName))
             {
-                if (context.PartialBlockTemplate == null)
+                var partialBlockTemplate = context.PartialBlockTemplate;
+
+                // If we are a block, our contents are the fallback and SpecialPartialBlockName refers to our parent
+                if (block)
+                {
+                    partialBlockTemplate = context.ParentContext.PartialBlockTemplate;
+                }
+
+                if (partialBlockTemplate == null)
                 {
                     return false;
                 }
 
-                var partialBlockTemplate = context.PartialBlockTemplate;
                 try
                 {
                     context.PartialBlockTemplate = context.ParentContext.PartialBlockTemplate;


### PR DESCRIPTION
I authored a partial-template with optional block-includes and happened to write `{{#>mail}}{{/mail}}` for the test-mail, as I did not need to adjust the optionals. This led to an exception similar to the one below:

```
System.InvalidOperationException
Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
   at HandlebarsDotNet.Compiler.PartialBlockAccumulatorContext.GetAccumulatedBlock() in ..\Handlebars.Net\source\Handlebars\Compiler\Lexer\Converter\BlockAccumulators\PartialBlockAccumulatorContext.cs:line 27
   at HandlebarsDotNet.Compiler.BlockAccumulator.AccumulateBlock(Expression parentItem, IEnumerator`1 enumerator, BlockAccumulatorContext context) in ..\Handlebars.Net\source\Handlebars\Compiler\Lexer\Converter\BlockAccumulator.cs:line 56
   at HandlebarsDotNet.Compiler.BlockAccumulator.ConvertTokens(IEnumerable`1 sequence)+MoveNext() in ..\Handlebars.Net\source\Handlebars\Compiler\Lexer\Converter\BlockAccumulator.cs:line 32
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at HandlebarsDotNet.Compiler.BlockAccumulator.Accumulate(IEnumerable`1 tokens, ICompiledHandlebarsConfiguration configuration) in ..\Handlebars.Net\source\Handlebars\Compiler\Lexer\Converter\BlockAccumulator.cs:line 13
   at HandlebarsDotNet.Compiler.ExpressionBuilder.ConvertTokensToExpressions(IEnumerable`1 tokens, ICompiledHandlebarsConfiguration configuration) in ..\Handlebars.Net\source\Handlebars\Compiler\ExpressionBuilder.cs:line 25
   at HandlebarsDotNet.Compiler.HandlebarsCompiler.Compile(ExtendedStringReader source, CompilationContext compilationContext) in ..\Handlebars.Net\source\Handlebars\Compiler\HandlebarsCompiler.cs:line 25
   at HandlebarsDotNet.HandlebarsEnvironment.Compile(TextReader template) in ..\Handlebars.Net\source\Handlebars\HandlebarsEnvironment.cs:line 145
   at HandlebarsDotNet.HandlebarsEnvironment.Compile(String template) in ..\Handlebars.Net\source\Handlebars\HandlebarsEnvironment.cs:line 188
   at HandlebarsDotNet.Handlebars.Compile(String template) in ..\Handlebars.Net\source\Handlebars\Handlebars.cs:line 63
   at HandlebarsDotNet.Test.InlinePartialTests.BasicBlockInlinePartial() in ..
```

Being new to Handlebars.Net it took me a while to understand what really was wrong. I no know, that I can change the template to `{{>mail}}`, but the exception isn't really helpful and I don't know why it shouldn't just render. So this pull-request allows block-includes with empty blocks.

On a side-note  `{{#>mail}}{{/mail}}` renders, if no `mail`-partial is present, while `{{>mail}}` throws an exception, if no `MissingPartialTemplateHandler` is registered. While not necessary for my use-case it may even be nice to have a syntax, that allows for optional partials out-of-the-box.