### PR TITLE
fix: strip invisible unicode chars from identifiers (issue #605)

### DIFF
--- a/source/Handlebars.Test/IssueTests.cs
+++ b/source/Handlebars.Test/IssueTests.cs
@@ -733,5 +733,33 @@ namespace HandlebarsDotNet.Test
 
             Assert.Throws<HandlebarsCompilerException>(()=> Handlebars.Compile(source));
         }
+
+        // Issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/605
+        // #if not evaluated when variable name contains invisible characters (BOM)
+        [Fact]
+        public void Issue605_IfNotEvaluatedWithBomCharacter()
+        {
+            // The ﻿ (BOM) is embedded in the identifier name
+            string source =
+                "<div class=\"entry\">\n" +
+                "<h1>{{title}}</h1>\n" +
+                "<div class=\"body\">\n" +
+                "{{body}}\n" +
+                "{{#if someCondition﻿}}\n" +
+                "<p>Show additional text</p>\n" +
+                "{{/if}}\n" +
+                "</div>\n" +
+                "</div>";
+
+            var handlebars = Handlebars.Create();
+            var template = handlebars.Compile(source);
+            var data = new {
+                title = "My new post",
+                body = "This is my first post!",
+                someCondition = true
+            };
+            var actual = template(data);
+            Assert.Contains("Show additional text", actual);
+        }
     }
 }

--- a/source/Handlebars/Compiler/Lexer/Parsers/WordParser.cs
+++ b/source/Handlebars/Compiler/Lexer/Parsers/WordParser.cs
@@ -11,6 +11,20 @@ namespace HandlebarsDotNet.Compiler.Lexer
         private const string ValidWordStartCharactersString = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$.@[]*";
         private static readonly HashSet<char> ValidWordStartCharacters = new HashSet<char>();
 
+        // Invisible Unicode characters that should be stripped from identifiers
+        // Includes BOM (U+FEFF), zero-width space (U+200B), zero-width non-joiner (U+200C),
+        // zero-width joiner (U+200D), word joiner (U+2060), and other format characters.
+        private static bool IsInvisibleCharacter(char c)
+        {
+            return c == '﻿' // BOM / Zero Width No-Break Space
+                || c == '​' // Zero Width Space
+                || c == '‌' // Zero Width Non-Joiner
+                || c == '‍' // Zero Width Joiner
+                || c == '⁠' // Word Joiner
+                || c == '᠎' // Mongolian Vowel Separator
+                || char.GetUnicodeCategory(c) == System.Globalization.UnicodeCategory.Format;
+        }
+
         static WordParser()
         {
             for (var index = 0; index < ValidWordStartCharactersString.Length; index++)
@@ -23,7 +37,7 @@ namespace HandlebarsDotNet.Compiler.Lexer
         {
             var context = reader.GetContext();
             if (!IsWord(reader)) return null;
-            
+
             var buffer = AccumulateWord(reader);
             return Token.Word(buffer, context);
         }
@@ -38,7 +52,7 @@ namespace HandlebarsDotNet.Compiler.Lexer
         {
             using var container = StringBuilderPool.Shared.Use();
             var buffer = container.Value;
-                
+
             var inString = false;
             var isEscaped = false;
 
@@ -65,7 +79,7 @@ namespace HandlebarsDotNet.Compiler.Lexer
                 {
                     var c = (char) node;
                     if (c == ']') isEscaped = false;
-                    
+
                     buffer.Append(c);
                     continue;
                 }
@@ -76,15 +90,22 @@ namespace HandlebarsDotNet.Compiler.Lexer
                     buffer.Append((char)node);
                     continue;
                 }
-                
+
                 if (node == '\'' || node == '"')
                 {
                     inString = !inString;
                 }
 
+                // Skip invisible Unicode characters (BOM, zero-width chars, etc.)
+                // that can appear in identifiers due to editor/encoding artifacts
+                if (!inString && IsInvisibleCharacter((char) node))
+                {
+                    continue;
+                }
+
                 buffer.Append((char)node);
             }
-                
+
             return buffer.Trim().ToString();
         }
     }


### PR DESCRIPTION
Fixes #605

BOM and other invisible Unicode characters embedded in identifier names caused #if and other expressions to silently fail. They are now stripped during parsing.