### PR TITLE
fix: parent context traversal inside custom block helpers in each (issue #539)

### DIFF
--- a/source/Handlebars.Test/IssueTests.cs
+++ b/source/Handlebars.Test/IssueTests.cs
@@ -733,5 +733,26 @@ namespace HandlebarsDotNet.Test
 
             Assert.Throws<HandlebarsCompilerException>(()=> Handlebars.Compile(source));
         }
+
+        // Issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/539
+        // Parent context (../) resolves to wrong value inside a custom block helper used within #each
+        [Fact]
+        public void Issue539_ParentContextInsideCustomBlockHelperInEach()
+        {
+            var handlebars = Handlebars.Create();
+            handlebars.RegisterHelper("ifCond", (writer, options, context, parameters) =>
+            {
+                if (parameters.Length == 3 && parameters[0]?.ToString() == parameters[2]?.ToString())
+                    options.Template(writer, context);
+                else
+                    options.Inverse(writer, context);
+            });
+
+            var source = @"{{#each loop}}{{#ifCond another '===' 'value'}}{{../this.foo}}{{/ifCond}}{{/each}}";
+            var template = handlebars.Compile(source);
+            var data = new { foo = "bar", loop = new object[] { new { another = "value" } } };
+            var result = template(data);
+            Assert.Equal("bar", result.Trim());
+        }
     }
 }

--- a/source/Handlebars/BlockHelperOptions.cs
+++ b/source/Handlebars/BlockHelperOptions.cs
@@ -71,7 +71,7 @@ namespace HandlebarsDotNet
         /// BlockHelper body
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Template(in EncodedTextWriter writer, in Context context) => Template(writer, context.Value);
+        public void Template(in EncodedTextWriter writer, in Context context) => OriginalTemplate(writer, Frame);
         
         /// <summary>
         /// BlockHelper body
@@ -113,7 +113,7 @@ namespace HandlebarsDotNet
         /// BlockHelper body
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Inverse(in EncodedTextWriter writer, in Context context) => Inverse(writer, context.Value);
+        public void Inverse(in EncodedTextWriter writer, in Context context) => OriginalInverse(writer, Frame);
         
         /// <summary>
         /// BlockHelper body


### PR DESCRIPTION
## Summary

Fixes #539

- `../` path traversal now correctly resolves to the parent of `#each` when used inside a custom block helper's template body.
- The bug was in `BlockHelperOptions.Template(EncodedTextWriter, Context)` and `BlockHelperOptions.Inverse(EncodedTextWriter, Context)`: when called with a `Context` struct, they unwrapped `context.Value` and created a new child frame via `Frame.CreateFrame(context.Value)`, introducing an extra level in the parent chain.
- Fix: pass `Frame` directly to the original template/inverse delegate, since `Frame` is already the correct current binding context (the `Context` struct was always created from `Frame`).

## Root cause

In `BlockHelperFunctionBinder`, the `BlockHelperOptions` is constructed with `Frame = bindingContext` (the `#each` iteration context). The `Context` struct passed to the helper is `new Context(bindingContext, bindingContext.Value)`. When the user calls `options.Template(writer, context)` (passing that same `Context` back), the old code did `Frame.CreateFrame(context.Value)`, which created a new child with `Frame` as its parent — so `../` inside the template resolved to `Frame.Value` (the loop element) instead of `Frame.ParentContext.Value` (the root data object).

## Test plan

- [x] Added regression test `Issue539_ParentContextInsideCustomBlockHelperInEach` to `IssueTests.cs` — confirmed it fails before the fix and passes after.
- [x] All 1747 existing tests pass with the fix applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)