### PR TITLE
fix: allow Unicode letters as first character in identifiers (issue #416)

### DIFF
--- a/source/Handlebars.Test/IssueTests.cs
+++ b/source/Handlebars.Test/IssueTests.cs
@@ -733,5 +733,19 @@ namespace HandlebarsDotNet.Test
 
             Assert.Throws<HandlebarsCompilerException>(()=> Handlebars.Compile(source));
         }
+
+        // Issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/416
+        // Non-ASCII characters not supported as the first character of a placeholder identifier
+        [Fact]
+        public void Issue416_UnicodeFirstCharacterInIdentifier()
+        {
+            var config = new HandlebarsConfiguration { TextEncoder = new HtmlEncoder() };
+            var handlebars = Handlebars.Create(config);
+            // Japanese characters as identifiers — first char is non-ASCII
+            var template = handlebars.Compile("Hello {{姓}} {{名}},");
+            var data = new Dictionary<string, object> { { "姓", "山田" }, { "名", "太郎" } };
+            var result = template(data);
+            Assert.Equal("Hello 山田 太郎,", result);
+        }
     }
 }

--- a/source/Handlebars/Compiler/Lexer/Parsers/WordParser.cs
+++ b/source/Handlebars/Compiler/Lexer/Parsers/WordParser.cs
@@ -31,7 +31,9 @@ namespace HandlebarsDotNet.Compiler.Lexer
         private static bool IsWord(ExtendedStringReader reader)
         {
             var peek = reader.Peek();
-            return ValidWordStartCharacters.Contains((char) peek);
+            if (peek == -1) return false;
+            var c = (char) peek;
+            return ValidWordStartCharacters.Contains(c) || char.IsLetter(c);
         }
 
         private static string AccumulateWord(ExtendedStringReader reader)


### PR DESCRIPTION
Fixes #416

## Summary

- `{{姓}}` (and any template expression whose identifier starts with a non-ASCII Unicode letter) previously failed with `"Reached unparseable token in expression: 姓}}"`.
- The root cause was in `WordParser.IsWord()` in `source/Handlebars/Compiler/Lexer/Parsers/WordParser.cs`: the check only accepted characters from a hard-coded ASCII set (`ValidWordStartCharacters`) and never fell through to accept Unicode letters.
- Fix: added `|| char.IsLetter(c)` to the start-character check so any Unicode letter (as defined by `System.Char`) is a valid identifier start — matching Handlebars.js behaviour.
- Continuation characters already accepted Unicode letters (the `AccumulateWord` loop only stops on `}`, `~`, `)`, `=`, or whitespace), so `{{a姓}}` already worked — only the first character was broken.

## Changes

- `source/Handlebars/Compiler/Lexer/Parsers/WordParser.cs` — one-line fix in `IsWord()`
- `source/Handlebars.Test/IssueTests.cs` — regression test `Issue416_UnicodeFirstCharacterInIdentifier`

## Test plan

- [ ] New test `Issue416_UnicodeFirstCharacterInIdentifier` fails before the fix and passes after.
- [ ] Full suite (1747 tests) passes with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)