### PR TITLE
fix: @partial-block usable in #if and as block partial (issue #519)

### DIFF
--- a/source/Handlebars.Test/IssueTests.cs
+++ b/source/Handlebars.Test/IssueTests.cs
@@ -733,5 +733,22 @@ namespace HandlebarsDotNet.Test
 
             Assert.Throws<HandlebarsCompilerException>(()=> Handlebars.Compile(source));
         }
+
+        // Issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/519
+        [Fact]
+        public void Issue519_PartialBlockUsableAsBlockAndInIf()
+        {
+            var handlebars = Handlebars.Create();
+            handlebars.RegisterTemplate("myPartial",
+                @"Conditional:{{#if @partial-block}} {{> @partial-block}}{{/if}}
+Plain: {{> @partial-block}}
+Block:{{#> @partial-block }}{{/@partial-block}}");
+
+            var render = handlebars.Compile("{{#> myPartial}}Block content{{/myPartial}}");
+            var actual = render(new { });
+            Assert.Contains("Conditional: Block content", actual);
+            Assert.Contains("Plain: Block content", actual);
+            Assert.Contains("Block:Block content", actual);
+        }
     }
 }

--- a/source/Handlebars/BindingContext.cs
+++ b/source/Handlebars/BindingContext.cs
@@ -156,7 +156,20 @@ namespace HandlebarsDotNet
                 return BlockParamsObject.TryGetValue(segment, out value)
                    || ContextDataObject.TryGetValue(wellKnownVariable, out value);
             }
-            
+
+            // Special handling for @partial-block: return the PartialBlockTemplate delegate
+            // so that {{#if @partial-block}} is truthy when a block partial is provided.
+            if (segment.LowerInvariant == "partial-block")
+            {
+                if (PartialBlockTemplate != null)
+                {
+                    value = PartialBlockTemplate;
+                    return true;
+                }
+                value = UndefinedBindingResult.Create(segment.TrimmedValue);
+                return false;
+            }
+
             return BlockParamsObject.TryGetValue(segment, out value)
                    || ContextDataObject.TryGetValue(segment, out value);
         }

--- a/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/PartialBlockAccumulatorContext.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/PartialBlockAccumulatorContext.cs
@@ -24,10 +24,16 @@ namespace HandlebarsDotNet.Compiler
 
         public override Expression GetAccumulatedBlock()
         {
+            Expression fallback = _body.Count == 0
+                ? null
+                : _body.Count == 1
+                    ? _body.First()
+                    : Expression.Block(_body);
+
             return HandlebarsExpression.Partial(
                 _startingNode.PartialName,
                 _startingNode.Argument,
-                _body.Count > 1 ? Expression.Block(_body) : _body.First());
+                fallback);
         }
 
         public override bool IsClosingElement(Expression item)


### PR DESCRIPTION
Fixes #519

## Summary

- `{{#if @partial-block}}` now correctly evaluates as truthy when the partial is invoked as a block partial (i.e., when a `@partial-block` template is in scope).
- `{{#> @partial-block }}{{/@partial-block}}` no longer crashes with `InvalidOperationException: Sequence contains no elements` when the body between the tags is empty.

## Root causes

**Bug 1 — `{{#if @partial-block}}` always falsy:**
`@partial-block` is a `PathType.Variable`, so its value is resolved via `BindingContext.TryGetContextVariable`. The `PartialBlockTemplate` is stored directly on `BindingContext` and was never exposed through the context data dictionary, so it always returned `UndefinedBindingResult` (falsy). Fixed by adding an explicit check in `TryGetContextVariable` for the segment name `partial-block` that returns the `PartialBlockTemplate` delegate when set.

**Bug 2 — `{{#> @partial-block }}{{/@partial-block}}` crashes:**
`PartialBlockAccumulatorContext.GetAccumulatedBlock()` called `_body.First()` unconditionally, which throws when the body is empty. Fixed by handling the empty-body case (passing `null` as the fallback, which is already the documented no-fallback sentinel in `PartialExpression`).

## Test plan

- [x] New regression test `Issue519_PartialBlockUsableAsBlockAndInIf` added to `IssueTests.cs` — exercises `{{#if @partial-block}}`, `{{> @partial-block}}`, and `{{#> @partial-block}}{{/@partial-block}}` in the same partial.
- [x] Full test suite: 1747 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)