### PR TITLE
fix: dictionary key access in nested #each with mixed Dict/List data (issue #466)

### DIFF
--- a/source/Handlebars.Test/IssueTests.cs
+++ b/source/Handlebars.Test/IssueTests.cs
@@ -733,5 +733,28 @@ namespace HandlebarsDotNet.Test
 
             Assert.Throws<HandlebarsCompilerException>(()=> Handlebars.Compile(source));
         }
+
+        // Issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/466
+        // Dictionary keys were inaccessible in nested #each when data is a mix of Dictionary and List
+        [Fact]
+        public void Issue466_NestedEachWithMixedDictionaryAndList()
+        {
+            var handlebars = Handlebars.Create();
+            var source = "{{#each this.users}}{{#each friends}}{{emailAddress}} {{/each}}{{/each}}";
+            var template = handlebars.Compile(source);
+
+            var friends = new List<Dictionary<object, object>>
+            {
+                new Dictionary<object, object> { { "emailAddress", "test@example.com" } }
+            };
+            var users = new List<Dictionary<object, object>>
+            {
+                new Dictionary<object, object> { { "friends", friends } }
+            };
+            var data = new Dictionary<object, object> { { "users", users } };
+
+            var result = template(data);
+            Assert.Contains("test@example.com", result);
+        }
     }
 }

--- a/source/Handlebars/MemberAccessors/DictionaryMemberAccessor.cs
+++ b/source/Handlebars/MemberAccessors/DictionaryMemberAccessor.cs
@@ -12,8 +12,22 @@ namespace HandlebarsDotNet.MemberAccessors
             // Only string keys supported - indexer takes an object, but no nice
             // way to check if the hashtable check if it should be a different type.
             var dictionary = (IDictionary) instance;
-            value = dictionary[memberName.LowerInvariant];
-            return true;
+
+            // Try the original-case key first to support camelCase and PascalCase keys
+            if (dictionary.Contains(memberName.TrimmedValue))
+            {
+                value = dictionary[memberName.TrimmedValue];
+                return true;
+            }
+
+            // Fall back to lowercase key for backward compatibility
+            if (memberName.LowerInvariant != memberName.TrimmedValue && dictionary.Contains(memberName.LowerInvariant))
+            {
+                value = dictionary[memberName.LowerInvariant];
+                return true;
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #466: dictionary keys with camelCase/PascalCase names (e.g. `emailAddress`) were inaccessible when used inside a nested `{{#each}}` over a `List<Dictionary<object,object>>`
- Root cause: `DictionaryMemberAccessor.TryGetValue` always looked up keys using their lowercase form (`LowerInvariant`), which failed case-sensitively against dictionaries that store mixed-case keys
- Fix: try `TrimmedValue` (original case) first; fall back to `LowerInvariant` for backward compatibility

## Test plan

- [x] Added `Issue466_NestedEachWithMixedDictionaryAndList` to `IssueTests.cs` — confirmed it fails before the fix and passes after
- [x] All 1747 existing tests still pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)