### PR TITLE
fix: #if in partial correctly evaluates explicitly passed context (issue #459)

### DIFF
--- a/source/Handlebars.Test/Issues/Issue459Tests.cs
+++ b/source/Handlebars.Test/Issues/Issue459Tests.cs
@@ -1,0 +1,18 @@
+using Xunit;
+
+namespace HandlebarsDotNet.Test
+{
+    public class Issue459Tests
+    {
+        [Fact]
+        public void Issue459_ConditionalInPartialSeesPassedContext()
+        {
+            var h = Handlebars.Create();
+            h.RegisterTemplate("LinkToCompany",
+                "{{#if ClientCode}}IT EXISTS{{else}}IT IS NOT HERE{{/if}}");
+            var template = h.Compile("{{> LinkToCompany Entity}}");
+            var data = new { Entity = new { ClientCode = "TEST" } };
+            Assert.Equal("IT EXISTS", template(data));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #459

- Adds a regression test (`source/Handlebars.Test/Issues/Issue459Tests.cs`) that verifies `{{#if}}` inside a partial correctly evaluates against the explicitly passed context object when calling `{{> PartialName Context}}`.
- The underlying bug was already fixed in the codebase prior to this PR; this test serves as a permanent regression guard to prevent future regressions.

## Test plan

- [x] New test `Issue459_ConditionalInPartialSeesPassedContext` passes
- [x] All 1747 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)