### PR TITLE
fix: case-sensitive resolution of same-spelling variables (issue #434)

### DIFF
--- a/source/Handlebars.Test/Issues/Issue434Tests.cs
+++ b/source/Handlebars.Test/Issues/Issue434Tests.cs
@@ -1,0 +1,22 @@
+using System.Dynamic;
+using Xunit;
+
+namespace HandlebarsDotNet.Test
+{
+    public class Issue434Tests
+    {
+        [Fact]
+        public void Issue434_CaseSensitiveLookupWithSameSpellingVariables()
+        {
+            var h = Handlebars.Create();
+            var template = h.Compile("{{TEST}} {{test}}");
+            dynamic data = new ExpandoObject();
+            data.TEST = "Upper";
+            data.test = "Lower";
+            var result = template(data);
+            var parts = result.Split(' ');
+            Assert.Equal("Upper", parts[0]);
+            Assert.Equal("Lower", parts[1]);
+        }
+    }
+}

--- a/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
@@ -46,6 +46,16 @@ namespace HandlebarsDotNet.Compiler
                 helper = new Ref<IHelperDescriptor<HelperOptions>>(lateBindHelperDescriptor);
                 configuration.Helpers.AddOrReplace(pathInfoLight, helper);
             }
+            else if (helper.Value is LateBindHelperDescriptor existingLateBindHelper
+                     && !string.Equals(existingLateBindHelper.Name.Path, pathInfo.Path, System.StringComparison.Ordinal))
+            {
+                // The helpers dictionary uses case-insensitive keys, so "TEST" and "test" map to the
+                // same slot. If the cached LateBindHelperDescriptor was stored for a differently-cased
+                // path, create a new one that carries the exact casing of the current expression so
+                // that runtime property lookup resolves to the right member.
+                var lateBindHelperDescriptor = new LateBindHelperDescriptor(pathInfo);
+                helper = new Ref<IHelperDescriptor<HelperOptions>>(lateBindHelperDescriptor);
+            }
             else if (configuration.Compatibility.RelaxedHelperNaming)
             {
                 pathInfoLight = pathInfoLight.TagComparer();


### PR DESCRIPTION
Fixes #434

When multiple variables share the same spelling but differ in case (e.g. `TEST` vs `test`), each now resolves to its own correctly-cased property.

## Root cause

`configuration.Helpers` uses a `FixedSizeDictionary` with a `PathInfoLightEqualityComparer` that compares keys case-insensitively. When `{{TEST}}` is compiled first, a `LateBindHelperDescriptor` keyed to `TEST` is stored. When `{{test}}` is compiled next, `TryGetValue` finds the `TEST` entry (same bucket), and the cached descriptor — which resolves `TEST` at runtime — is reused unchanged. So both expressions resolve the same `TEST` property.

## Fix

In `PathBinder.VisitPathExpression`, after a successful `TryGetValue`, check whether the found entry is a `LateBindHelperDescriptor` whose stored `Name.Path` differs (by ordinal) from the current `pathInfo.Path`. If so, create a new `LateBindHelperDescriptor` with the correct case. The new descriptor is used for this expression only (not re-stored in the dictionary, since the case-insensitive slot is already occupied).

## Test plan

- [x] New test `Issue434_CaseSensitiveLookupWithSameSpellingVariables` in `source/Handlebars.Test/Issues/Issue434Tests.cs` — confirmed red before fix, green after
- [x] Full test suite: 1747 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)