### PR TITLE
fix: named args in partial work in nested #each (issue #455)

### DIFF
--- a/source/Handlebars.Test/Issues/Issue455Tests.cs
+++ b/source/Handlebars.Test/Issues/Issue455Tests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+
+namespace HandlebarsDotNet.Test
+{
+    public class Issue455Tests
+    {
+        // issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/455
+        [Fact]
+        public void Issue455_NamedArgsInPartialInsideNestedEach()
+        {
+            var h = Handlebars.Create();
+            h.RegisterTemplate("myPartial", "{{arg1}}-{{arg2}} ");
+            var template = h.Compile(
+                "{{#each items}}{{#each nested}}{{> myPartial arg1=value1 arg2=value2}}{{/each}}{{/each}}");
+            var data = new
+            {
+                items = new[] { new { nested = new[] { new { value1 = "A", value2 = "B" }, new { value1 = "C", value2 = "D" } } } }
+            };
+            var result = template(data);
+            Assert.Contains("A-B", result);
+            Assert.Contains("C-D", result);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #455

## Summary

- Named partial hash parameters (`{{> myPartial arg1=value1 arg2=value2}}`) inside a nested `{{#each}}` loop were reported to throw `ArgumentOutOfRangeException`.
- Investigation found that the existing fix for issue #422 (`BindingContext.PopulateHash` guarding against `ObjectDescriptor.Empty`) already covers the nested `#each` case as well.
- This PR adds a regression test in `source/Handlebars.Test/Issues/Issue455Tests.cs` to explicitly document and lock in this behavior.

## Test plan

- [x] New test `Issue455_NamedArgsInPartialInsideNestedEach` added to `Issue455Tests.cs`
- [x] Test passes with the current codebase (the #422 fix covers this)
- [x] Full test suite (1747 tests) passes with no regressions

Partial hash parameters no longer throw `ArgumentOutOfRangeException` when used inside a nested `#each` loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)