### PR TITLE
fix: UpperCamelCaseExpressionNameResolver no longer breaks #each (issue #582)

### DIFF
--- a/source/Handlebars.Test/Issues/Issue582Tests.cs
+++ b/source/Handlebars.Test/Issues/Issue582Tests.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace HandlebarsDotNet.Test
+{
+    public class Issue582Tests
+    {
+        private static IHandlebars CreateHandlebars()
+        {
+            var config = new HandlebarsConfiguration
+            {
+                ExpressionNameResolver = new HandlebarsDotNet.Compiler.Resolvers.UpperCamelCaseExpressionNameResolver()
+            };
+            return Handlebars.Create(config);
+        }
+
+        [Fact]
+        public void Issue582_UpperCamelCaseResolverDoesNotBreakEachIteration()
+        {
+            var h = CreateHandlebars();
+            var template = h.Compile("{{#each items}}{{name}} {{/each}}");
+            var data = new { items = new[] { new { name = "Alice" }, new { name = "Bob" } } };
+            Assert.Equal("Alice Bob ", template(data));
+        }
+
+        [Fact]
+        public void Issue582_UpperCamelCaseResolverDoesNotBreakEachWithList()
+        {
+            var h = CreateHandlebars();
+            var template = h.Compile("{{#each items}}{{name}} {{/each}}");
+            var data = new
+            {
+                items = new List<object>
+                {
+                    new { name = "Alice" },
+                    new { name = "Bob" }
+                }
+            };
+            Assert.Equal("Alice Bob ", template(data));
+        }
+
+        [Fact]
+        public void Issue582_UpperCamelCaseResolverDoesNotBreakEachWithAtIndex()
+        {
+            var h = CreateHandlebars();
+            var template = h.Compile("{{#each items}}{{@index}}:{{name}} {{/each}}");
+            var data = new { items = new[] { new { name = "Alice" }, new { name = "Bob" } } };
+            Assert.Equal("0:Alice 1:Bob ", template(data));
+        }
+
+        [Fact]
+        public void Issue582_UpperCamelCaseResolverDoesNotBreakEachWithAtFirst()
+        {
+            var h = CreateHandlebars();
+            var template = h.Compile("{{#each items}}{{#if @first}}first:{{/if}}{{name}} {{/each}}");
+            var data = new { items = new[] { new { name = "Alice" }, new { name = "Bob" } } };
+            Assert.Equal("first:Alice Bob ", template(data));
+        }
+
+        [Fact]
+        public void Issue582_UpperCamelCaseResolverWorksWithNestedPropertyAccess()
+        {
+            var h = CreateHandlebars();
+            var template = h.Compile("{{#each items}}{{address.city}} {{/each}}");
+            var data = new
+            {
+                items = new[]
+                {
+                    new { address = new { city = "New York" } },
+                    new { address = new { city = "London" } }
+                }
+            };
+            Assert.Equal("New York London ", template(data));
+        }
+
+        [Fact]
+        public void Issue582_UpperCamelCaseResolverWorksWithStringArray()
+        {
+            var h = CreateHandlebars();
+            var template = h.Compile("{{#each items}}{{this}} {{/each}}");
+            var data = new { items = new[] { "Alice", "Bob" } };
+            Assert.Equal("Alice Bob ", template(data));
+        }
+
+        [Fact]
+        public void Issue582_UpperCamelCaseResolverWorksWithNestedEach()
+        {
+            var h = CreateHandlebars();
+            var template = h.Compile("{{#each groups}}{{#each members}}{{name}} {{/each}}{{/each}}");
+            var data = new
+            {
+                groups = new[]
+                {
+                    new { members = new[] { new { name = "Alice" }, new { name = "Bob" } } },
+                    new { members = new[] { new { name = "Carol" } } }
+                }
+            };
+            Assert.Equal("Alice Bob Carol ", template(data));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #582

## Summary

- Adds `source/Handlebars.Test/Issues/Issue582Tests.cs` with 7 regression tests covering `UpperCamelCaseExpressionNameResolver` + `#each` interaction
- Tests confirm the resolver does not break `#each` iteration over arrays or lists, including scenarios with `@index`/`@first` metadata, nested property access, string arrays, and nested `#each` blocks

## Analysis

The bug was reported as `{{#each items}}{{name}}{{/each}}` producing wrong output when `ExpressionNameResolver = new UpperCamelCaseExpressionNameResolver()` is configured.

After tracing through the code, the current resolver is safe because:

1. **Member access** (`ReflectionMemberAccessor.GetValueGetter`) compares against `ChainSegment.LowerInvariant` using `OrdinalIgnoreCase`, so `ChainSegment("Name")` and `ChainSegment("name")` resolve to the same property.
2. **Context data lookups** use `ChainSegmentEqualityComparer` which also compares by `LowerInvariant`, so resolver-transformed segments still match the stored well-known variables.
3. **Reserved names** (`this`, `@index`, `@key`, `@first`, `@last`, `@root`) go through code paths that never call `ResolveMemberName` (the only place the resolver is invoked).

The tests lock in this correct behavior to catch any future regression.

## Test plan

- [x] All 7 new tests pass
- [x] All 1753 tests pass (1746 pre-existing + 7 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)