### PR TITLE
test: regression guard for block params in nested with/each (issue #595)

### DIFF
--- a/source/Handlebars.Test/Issues/Issue595Tests.cs
+++ b/source/Handlebars.Test/Issues/Issue595Tests.cs
@@ -1,0 +1,160 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace HandlebarsDotNet.Test
+{
+    // Issue https://github.com/Handlebars-Net/Handlebars.Net/issues/595
+    // NotSupportedException: TypeConverter cannot convert UndefinedBindingResult
+    // when using `{{#with this as |field|}}` inside `{{#each Fields}}` and then
+    // passing `field` as an argument to a helper in an inner `{{#each (helper field)}}`.
+    public class Issue595Tests
+    {
+        [Fact]
+        public void BlockParamFromWithShouldBePassableToHelperInInnerEach()
+        {
+            var handlebars = Handlebars.Create();
+            var receivedArgs = new List<object>();
+
+            handlebars.RegisterHelper("Getattributes", (context, arguments) =>
+            {
+                receivedArgs.Add(arguments[0]);
+                return new[] { "attr1", "attr2" };
+            });
+
+            var template = handlebars.Compile(
+                "{{#each Fields}}" +
+                "{{#with this as |field|}}" +
+                "{{#each (Getattributes field)}}" +
+                "{{this}} " +
+                "{{/each}}" +
+                "{{/with}}" +
+                "{{/each}}"
+            );
+
+            var data = new
+            {
+                Fields = new[] { "field1", "field2" }
+            };
+
+            // Should not throw NotSupportedException: TypeConverter cannot convert UndefinedBindingResult
+            var result = template(data);
+
+            Assert.Equal("attr1 attr2 attr1 attr2 ", result);
+
+            // Verify that the helper received the actual field values, not UndefinedBindingResult
+            Assert.Equal(2, receivedArgs.Count);
+            Assert.Equal("field1", receivedArgs[0]);
+            Assert.Equal("field2", receivedArgs[1]);
+        }
+
+        [Fact]
+        public void BlockParamTypedAccessShouldNotThrowWhenPassedToHelper()
+        {
+            // Reproduces the exact error:
+            // System.NotSupportedException: TypeConverter cannot convert UndefinedBindingResult to string
+            // The bug manifests when field resolves to UndefinedBindingResult and the helper
+            // uses arguments.At<T>() (typed access) which calls TypeConverter.ConvertTo.
+            var handlebars = Handlebars.Create();
+            var receivedArgs = new List<string>();
+
+            handlebars.RegisterHelper("Getattributes", (context, arguments) =>
+            {
+                // Using At<T>() typed access triggers the NotSupportedException if
+                // arguments[0] is UndefinedBindingResult rather than the actual field value
+                var fieldValue = arguments.At<string>(0);
+                receivedArgs.Add(fieldValue);
+                return new[] { "attr1", "attr2" };
+            });
+
+            var template = handlebars.Compile(
+                "{{#each Fields}}" +
+                "{{#with this as |field|}}" +
+                "{{#each (Getattributes field)}}" +
+                "{{this}} " +
+                "{{/each}}" +
+                "{{/with}}" +
+                "{{/each}}"
+            );
+
+            var data = new
+            {
+                Fields = new[] { "field1", "field2" }
+            };
+
+            // Should not throw NotSupportedException: TypeConverter cannot convert UndefinedBindingResult to string
+            var result = template(data);
+
+            Assert.Equal("attr1 attr2 attr1 attr2 ", result);
+            Assert.Equal(2, receivedArgs.Count);
+            Assert.Equal("field1", receivedArgs[0]);
+            Assert.Equal("field2", receivedArgs[1]);
+        }
+
+        [Fact]
+        public void BlockParamFromWithShouldBePassableToHelperInInnerEachMultipleIterations()
+        {
+            // This test uses more iterations to increase the chance of pool reuse,
+            // which is what triggers the stale-data bug.
+            var handlebars = Handlebars.Create();
+            var receivedArgs = new List<string>();
+
+            handlebars.RegisterHelper("Getattributes", (context, arguments) =>
+            {
+                var fieldValue = arguments.At<string>(0);
+                receivedArgs.Add(fieldValue);
+                return new[] { "x", "y" };
+            });
+
+            var template = handlebars.Compile(
+                "{{#each Fields}}" +
+                "{{#with this as |field|}}" +
+                "{{#each (Getattributes field)}}" +
+                "{{this}}" +
+                "{{/each}}" +
+                "{{/with}}" +
+                "{{/each}}"
+            );
+
+            var data = new
+            {
+                Fields = new[] { "a", "b", "c", "d", "e" }
+            };
+
+            var result = template(data);
+
+            Assert.Equal("xyxyxyxyxy", result);
+            Assert.Equal(5, receivedArgs.Count);
+            Assert.Equal(new[] { "a", "b", "c", "d", "e" }, receivedArgs);
+        }
+
+        [Fact]
+        public void Issue595_WithBlockParamsInEach_DoesNotThrow()
+        {
+            // Canonical 1000-iteration stress test to exercise BindingContext pool reuse.
+            // If the block param `field` ever resolves to UndefinedBindingResult due to
+            // pool reuse corruption, the helper would receive a wrong value (or throw
+            // NotSupportedException when typed access is used).
+            var h = Handlebars.Create();
+            h.RegisterHelper("Getattributes", (context, args) => new[] { "attr1", "attr2" });
+
+            var template = h.Compile(
+                "{{#each Fields}}" +
+                "{{#with this as |field|}}" +
+                "{{#each (Getattributes field)}}" +
+                "{{this}} " +
+                "{{/each}}" +
+                "{{/with}}" +
+                "{{/each}}");
+
+            var data = new { Fields = new object[] { new { Name = "f1" }, new { Name = "f2" } } };
+
+            // Run many times to stress pool reuse
+            for (int i = 0; i < 1000; i++)
+            {
+                var result = template(data);
+                Assert.Contains("attr1", result);
+                Assert.Contains("attr2", result);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #595

This PR adds regression tests in `source/Handlebars.Test/Issues/Issue595Tests.cs` for the reported `NotSupportedException: TypeConverter cannot convert UndefinedBindingResult` when using `{{#with this as |field|}}` inside `{{#each Fields}}` and then passing `field` to a helper inside a nested `{{#each (helper field)}}`.

## Findings: Bug is NOT reproducible in current code

Two previous agents investigated this issue and could not reproduce the exception. This agent confirmed the same conclusion:

- All 4 regression tests pass, including a **1000-iteration stress test** designed to exercise `BindingContext` pool reuse (the claimed root cause)
- The `FixedSizeDictionary.OptionalClear()` path (called when returning a `BindingContext` to the pool) increments `_version`, which invalidates all `EntryIndex` objects from the previous use. Subsequent lookups via `TryGetValue(in EntryIndex<TKey> keyIndex, ...)` check `keyIndex.Version != _version` and correctly return `false` — so stale block-param slots from prior pool tenants are never served to new callers
- The `300f2f6 Improve object pool safety` commit (Mar 2022) and `8a58d30 fix: prevent unbounded DictionarySlim growth when replacing existing keys (issue #541)` commit are the likely fixes that made this class of bug non-reproducible on current `main`

## Tests added

| Test | What it checks |
|------|---------------|
| `BlockParamFromWithShouldBePassableToHelperInInnerEach` | Basic end-to-end: block param resolves to actual field value (not `UndefinedBindingResult`) |
| `BlockParamTypedAccessShouldNotThrowWhenPassedToHelper` | Uses `arguments.At<string>(0)` (typed access) which would throw `NotSupportedException` if the value were `UndefinedBindingResult` |
| `BlockParamFromWithShouldBePassableToHelperInInnerEachMultipleIterations` | 5-field loop with multiple pool cycles |
| `Issue595_WithBlockParamsInEach_DoesNotThrow` | Canonical 1000-iteration stress test from the issue report |

## Test plan

- [x] `dotnet test --filter "Issue595"` — 4/4 passed
- [x] No production code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)