### PR TITLE
fix: case-sensitive key lookup for IDictionary/Hashtable (issue #521)

### DIFF
--- a/source/Handlebars.Test/IssueTests.cs
+++ b/source/Handlebars.Test/IssueTests.cs
@@ -733,5 +733,41 @@ namespace HandlebarsDotNet.Test
 
             Assert.Throws<HandlebarsCompilerException>(()=> Handlebars.Compile(source));
         }
+
+        // Issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/521
+        // Hashtable with an uppercase key should be accessible using the same-cased expression.
+        // The IDictionary accessor was incorrectly lowercasing the lookup key.
+        [Fact]
+        public void HashtableUppercaseKeyResolvesWithMatchingExpression()
+        {
+            var template = Handlebars.Compile("Hello {{NAME}}");
+            var result = template(new Hashtable { { "NAME", "alice" } });
+            Assert.Equal("Hello alice", result);
+        }
+
+        [Fact]
+        public void HashtableLowercaseKeyStillResolves()
+        {
+            var template = Handlebars.Compile("Hello {{name}}");
+            var result = template(new Hashtable { { "name", "bob" } });
+            Assert.Equal("Hello bob", result);
+        }
+
+        [Fact]
+        public void GenericDictionaryUppercaseKeyUnchanged()
+        {
+            var template = Handlebars.Compile("Hello {{NAME}}");
+            var result = template(new Dictionary<string, string> { { "NAME", "charlie" } });
+            Assert.Equal("Hello charlie", result);
+        }
+
+        [Fact]
+        public void HashtableLookupIsCaseSensitive()
+        {
+            // {{name}} should NOT resolve a key "NAME" — JS objects are case-sensitive
+            var template = Handlebars.Compile("Hello {{name}}");
+            var result = template(new Hashtable { { "NAME", "dave" } });
+            Assert.Equal("Hello ", result);
+        }
     }
 }

--- a/source/Handlebars/MemberAccessors/DictionaryMemberAccessor.cs
+++ b/source/Handlebars/MemberAccessors/DictionaryMemberAccessor.cs
@@ -12,7 +12,7 @@ namespace HandlebarsDotNet.MemberAccessors
             // Only string keys supported - indexer takes an object, but no nice
             // way to check if the hashtable check if it should be a different type.
             var dictionary = (IDictionary) instance;
-            value = dictionary[memberName.LowerInvariant];
+            value = dictionary[memberName.TrimmedValue];
             return true;
         }
     }


### PR DESCRIPTION
## Summary

- Fixes #521
- `Hashtable` (and any other non-generic `IDictionary`) with an uppercase key (e.g. `"NAME"`) was silently returning empty when accessed via `{{NAME}}` in a template, while `Dictionary<string, string>` with the same key worked correctly.
- `Hashtable` with a lowercase key also incorrectly resolved for any casing in the template expression, violating case-sensitive JS object key semantics.

## Root cause

In `DictionaryMemberAccessor.TryGetValue`, the lookup was performed using `memberName.LowerInvariant` instead of `memberName.TrimmedValue`. This bug was introduced in commit `9d52004` when the `string memberName` parameter was replaced with `ChainSegment memberName` — `LowerInvariant` was chosen instead of `TrimmedValue`.

The original code (pre-refactor) used the raw string with no case folding, which is the correct behaviour.

## Fix

One-line change in `source/Handlebars/MemberAccessors/DictionaryMemberAccessor.cs`:

```diff
-value = dictionary[memberName.LowerInvariant];
+value = dictionary[memberName.TrimmedValue];
```

## JS parity

Handlebars.js resolves object keys case-sensitively (`{{NAME}}` on `{ NAME: "bob" }` works; `{{NAME}}` on `{ name: "bob" }` does not). This fix restores that behaviour for `IDictionary`/`Hashtable`.

## Test plan

Four new regression tests added to `IssueTests.cs`:

- [x] `Hashtable` with uppercase key resolves correctly via matching expression
- [x] `Hashtable` with lowercase key still resolves via matching expression
- [x] `Dictionary<string, string>` with uppercase key still works (no regression)
- [x] `{{name}}` does NOT resolve a `Hashtable` key `"NAME"` (case-sensitive, JS-parity)

All 1750 existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)