### PR TITLE
fix: switch NuGet release publishing to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ jobs:
   publish:
     name: Publish
     runs-on: windows-latest
+    environment: release
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -33,8 +36,12 @@ jobs:
         working-directory: ./source
         run: dotnet pack -c Release /p:version=${{ github.event.release.tag_name }} /p:ContinuousIntegrationBuild=true /p:AssemblyOriginatorKeyFile=${{ steps.obtain_snk.outputs.filePath }} /p:ShouldSignAssembly=true
 
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        id: login
+        with:
+          user: Handlebars-Net
+
       - name: Publish to NuGet
         working-directory: ./source
-        env:
-          NUGET_KEY: ${{ secrets.NUGET_ORG_PUSH_KEY }}
-        run: dotnet nuget push **/*.nupkg -k $env:NUGET_KEY -s https://api.nuget.org/v3/index.json
+        run: dotnet nuget push **/*.nupkg -k ${{ steps.login.outputs.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json


### PR DESCRIPTION
## Summary
- The `2.2.0` release run failed publishing to nuget.org with a 403 (`NUGET_ORG_PUSH_KEY` secret invalid/expired).
- Replaces the static API key push with [NuGet.org Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing): the job requests a GitHub OIDC token and exchanges it for a short-lived NuGet API key via `NuGet/login`.
- Job is scoped to the `release` GitHub Actions environment and `user: Handlebars-Net`, matching the trusted publisher policy already configured on nuget.org.

## Test plan
- [ ] Merge this PR
- [ ] Re-run the failed `2.2.0` release workflow run and confirm the package publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)