### PR TITLE
ci: skip benchmark run for PRs that don't touch benchmark-relevant paths

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -97,15 +97,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Check for benchmark-relevant changes
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'source/Handlebars/**'
+              - 'source/Handlebars.Benchmark/**'
+              - 'source/Directory.Build.props'
+              - 'source/Handlebars.sln'
+
       - uses: actions/setup-dotnet@v4
+        if: steps.filter.outputs.relevant == 'true'
         with:
           dotnet-version: |
               6.0.x
               10.0.x
       - name: Run benchmark
+        if: steps.filter.outputs.relevant == 'true'
         working-directory: ./source/Handlebars.Benchmark
         run: dotnet run -c Release -f net10.0 --exporters json --filter '*' --join
       - name: Get benchmark file name
+        if: steps.filter.outputs.relevant == 'true'
         working-directory: ./source/Handlebars.Benchmark/BenchmarkDotNet.Artifacts/results
         id: benchmarkfilename
         run: |
@@ -113,6 +128,7 @@ jobs:
           echo $filePath
           echo "file=$filePath" >> $GITHUB_OUTPUT
       - name: Store benchmark result
+        if: steps.filter.outputs.relevant == 'true'
         uses: Happypig375/github-action-benchmark@e7cb068f90622402c0ae5b54e2c781052fcd9343 # v1.8.2
         with:
           name: Benchmark.Net Benchmark
@@ -125,7 +141,12 @@ jobs:
           fail-on-alert: false
           alert-comment-cc-users: '@zjklee'
       - name: Upload Artifacts
+        if: steps.filter.outputs.relevant == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: Benchmark
           path: source/Handlebars.Benchmark/BenchmarkDotNet.Artifacts/results/
+
+      - name: Skipped
+        if: steps.filter.outputs.relevant != 'true'
+        run: echo "No changes under source/Handlebars or source/Handlebars.Benchmark — skipping benchmark run."


### PR DESCRIPTION
## Summary
- \`Run Benchmark.Net\` is a required status check on \`master\`, so a PR that only touches e.g. workflow yaml or docs still has to wait for a full BenchmarkDotNet run.
- Can't just path-filter the workflow trigger to skip it — a required check that never runs stays "pending" forever and blocks merge.
- Instead, the job always runs but now starts with a \`dorny/paths-filter\` check against \`source/Handlebars/**\`, \`source/Handlebars.Benchmark/**\`, \`source/Directory.Build.props\`, and \`source/Handlebars.sln\`. The actual \`dotnet run\` benchmark, result storage, and artifact upload steps are skipped (fast success) when none of those changed.

## Test plan
- [ ] Confirm this PR itself (which only touches \`pull_request.yml\`) skips the benchmark run and reports success quickly
- [ ] Open a follow-up PR that touches \`source/Handlebars/**\` and confirm the benchmark still runs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)