### PR TITLE
fix: use policy creator's nuget.org username for trusted publishing login

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         id: login
         with:
-          user: Handlebars-Net
+          user: rexm
 
       - name: Publish to NuGet
         working-directory: ./source


### PR DESCRIPTION
## Summary
- Follow-up to #644. The first live release attempt failed the OIDC token exchange: nuget.org returned "No matching trust policy owned by user 'Handlebars-Net' was found. Make sure you are using the username of the policy creator, not the policy owner."
- The trusted publishing policy is owned by the `Handlebars-Net` org, but was created under `rexm`'s nuget.org account — `NuGet/login`'s `user` input needs the creator's username, not the owner.

## Test plan
- [ ] Merge this PR
- [ ] Move the `2.2.0` tag to the merge commit and re-trigger the release to confirm the package publishes