### PR TITLE
fix: support hash arguments for inline partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,21 @@ var result = template(data);
 */
 ```
 
+Partials, including inline partials declared with `{{#*inline}}`, accept hash arguments at the call site. The hash values are merged into the partial's context alongside any properties inherited from the calling context:
+
+```c#
+string source =
+@"{{#*inline ""user""}}<strong>{{name}}</strong>{{/inline}}{{> user name=""Karen""}}";
+
+var template = Handlebars.Compile(source);
+
+var result = template(null);
+
+/* Would render:
+<strong>Karen</strong>
+*/
+```
+
 ### Registering Helpers
 
 ```c#

--- a/source/Handlebars.Test/InlinePartialTests.cs
+++ b/source/Handlebars.Test/InlinePartialTests.cs
@@ -244,6 +244,29 @@ namespace HandlebarsDotNet.Test
         }
 
         [Fact]
+        public void InlinePartialDefinitionWithExtraArgumentDoesNotThrow()
+        {
+            // Regression test for https://github.com/Handlebars-Net/Handlebars.Net/issues/560
+            string source = "{{#*inline \"my_partial\" arg}}{{arg}}{{/inline}}{{>my_partial}}";
+
+            var template = Handlebars.Compile(source);
+            var result = template(null);
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void InlinePartialDefinitionWithHashArgumentDoesNotThrow()
+        {
+            string source = "{{#*inline \"my_partial\" arg=5}}{{arg}}{{/inline}}{{>my_partial}}";
+
+            var template = Handlebars.Compile(source);
+            var result = template(null);
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
         public void BasicBlockInlinePartial()
         {
             string source = "Hello, {{#>personInline}}friend{{/personInline}}!";

--- a/source/Handlebars/Decorators/InlineBlockDecoratorDescriptor.cs
+++ b/source/Handlebars/Decorators/InlineBlockDecoratorDescriptor.cs
@@ -7,9 +7,9 @@ namespace HandlebarsDotNet.Decorators
     {
         public TemplateDelegate Invoke(in TemplateDelegate function, in BlockDecoratorOptions options, in Context context, in Arguments arguments)
         {
-            if (arguments.Length != 1)
+            if (arguments.Length == 0)
             {
-                throw new HandlebarsRuntimeException("{{*inline}} helper must have exactly one argument");
+                throw new HandlebarsRuntimeException("{{*inline}} helper must have at least one argument");
             }
 
             var bindingContext = options.Frame;


### PR DESCRIPTION
## Summary
- `{{#*inline "name" ...}}` decorator required exactly 1 argument, so passing hash arguments (or any extra positional arg) threw `HandlebarsRuntimeException`. Relaxed the check to only require the partial name argument, ignoring extras — matching Handlebars.js's own `inline` decorator behavior.
- Hash arguments at the invocation site (`{{> myPartial key=value}}`) already worked identically for inline and registered partials; that path was unaffected.

## Test plan
- [x] Added regression tests in `InlinePartialTests.cs` covering the issue's exact repro plus a hash-argument variant
- [x] Full test suite passes (1840/1840)

Fixes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)