### PR TITLE
bench: add RenderToString suite covering the string-returning API

### DIFF
--- a/source/Handlebars.Benchmark/RenderToString.cs
+++ b/source/Handlebars.Benchmark/RenderToString.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using HandlebarsDotNet;
+
+namespace HandlebarsNet.Benchmark
+{
+    // Render time for the string-returning template API — the most common way the
+    // library is consumed. Unlike the other Render* benchmarks (which write to
+    // TextWriter.Null and therefore only measure resolution overhead), this suite
+    // pays the real output cost: HTML encoding and StringBuilder-backed writes.
+    //
+    // Content=clean:  values contain nothing that needs HTML escaping (typical data).
+    // Content=html:   values are dense with characters that must be escaped (worst case).
+    [MemoryDiagnoser]
+    public class RenderToString
+    {
+        private HandlebarsTemplate<object, object> _template;
+        private object _data;
+
+        private const int ItemCount = 50;
+
+        private const string Source =
+            "<ul>" +
+            "{{#each items}}" +
+            "<li id=\"item-{{@index}}\"><span>{{name}}</span> &mdash; {{description}} " +
+            "<em>x{{qty}}</em>{{#if onSale}} <strong>SALE</strong>{{/if}}</li>" +
+            "{{/each}}" +
+            "</ul>";
+
+        [Params("clean", "html")]
+        public string Content { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var handlebars = Handlebars.Create();
+            _template = handlebars.Compile(Source);
+
+            var description = Content == "clean"
+                ? "Reliable everyday item for home and office use"
+                : "Fast & reliable <everyday> item \"for\" home & office use";
+
+            var items = new List<object>(ItemCount);
+            for (var i = 0; i < ItemCount; i++)
+            {
+                items.Add(new
+                {
+                    name = $"Product {i:D4}",
+                    description,
+                    qty = i * 7 + 1,
+                    onSale = i % 3 == 0
+                });
+            }
+
+            _data = new { items };
+        }
+
+        [Benchmark]
+        public string Render() => _template(_data);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `RenderToString` benchmark suite covering the string-returning template API — the most common way the library is consumed in practice.

## Why

All existing `Render*` suites invoke templates against `TextWriter.Null`. That measures path-resolution and iteration overhead well, but a no-op writer hides the entire output side of rendering: HTML encoding and the actual `StringBuilder`-backed writes. During benchmarking of output-path optimizations, `TextWriter.Null` produced misleading results in both directions — it understated real-world wins (per-char writes are nearly free on a null writer) and manufactured regressions that don't exist for real writers (`TextWriter`'s base span implementation rents/copies via `ArrayPool`, which `StringWriter`/`StreamWriter` never hit).

## What it measures

- A 50-item `{{#each}}` list template rendered through `HandlebarsTemplate<object, object>` (i.e. `template(data)` returning a `string`), which exercises the pooled `ReusableStringWriter` path.
- Two content cases:
  - `clean` — values contain nothing that needs HTML escaping (typical data);
  - `html` — values are dense with characters that must be escaped (worst case for encoder fast paths).

Runtime cost: ~1 minute per full suite run (2 cases × ~30s), well within the benchmark time budget.

## Baseline numbers (master, Apple M4, .NET 10)

| Method | Content | Mean     | Error    | StdDev   | Gen0   | Gen1   | Allocated |
|------- |-------- |---------:|---------:|---------:|-------:|-------:|----------:|
| Render | clean   | 13.95 us | 0.108 us | 0.095 us | 3.9215 | 0.2289 |  32.09 KB |
| Render | html    | 14.75 us | 0.118 us | 0.110 us | 4.3030 | 0.2594 |  35.31 KB |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
