### PR TITLE
perf: bulk-write clean runs in HTML encoders (~10-20% faster string-heavy rendering)

### DIFF
--- a/source/Handlebars.Benchmark/RenderToString.cs
+++ b/source/Handlebars.Benchmark/RenderToString.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using HandlebarsDotNet;
+
+namespace HandlebarsNet.Benchmark
+{
+    // Render time for the string-returning template API — the most common way the
+    // library is consumed. Unlike the other Render* benchmarks (which write to
+    // TextWriter.Null and therefore only measure resolution overhead), this suite
+    // pays the real output cost: HTML encoding and StringBuilder-backed writes.
+    //
+    // Content=clean:  values contain nothing that needs HTML escaping (typical data).
+    // Content=html:   values are dense with characters that must be escaped (worst case).
+    [MemoryDiagnoser]
+    public class RenderToString
+    {
+        private HandlebarsTemplate<object, object> _template;
+        private object _data;
+
+        private const int ItemCount = 50;
+
+        private const string Source =
+            "<ul>" +
+            "{{#each items}}" +
+            "<li id=\"item-{{@index}}\"><span>{{name}}</span> &mdash; {{description}} " +
+            "<em>x{{qty}}</em>{{#if onSale}} <strong>SALE</strong>{{/if}}</li>" +
+            "{{/each}}" +
+            "</ul>";
+
+        [Params("clean", "html")]
+        public string Content { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var handlebars = Handlebars.Create();
+            _template = handlebars.Compile(Source);
+
+            var description = Content == "clean"
+                ? "Reliable everyday item for home and office use"
+                : "Fast & reliable <everyday> item \"for\" home & office use";
+
+            var items = new List<object>(ItemCount);
+            for (var i = 0; i < ItemCount; i++)
+            {
+                items.Add(new
+                {
+                    name = $"Product {i:D4}",
+                    description,
+                    qty = i * 7 + 1,
+                    onSale = i % 3 == 0
+                });
+            }
+
+            _data = new { items };
+        }
+
+        [Benchmark]
+        public string Render() => _template(_data);
+    }
+}

--- a/source/Handlebars/IO/HtmlEncoder.cs
+++ b/source/Handlebars/IO/HtmlEncoder.cs
@@ -64,15 +64,21 @@ namespace HandlebarsDotNet
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void WriteRun(string text, int start, int length, TextWriter target)
         {
-#if NETSTANDARD2_0
+#if !NETSTANDARD2_0
+            // StringWriter and StreamWriter override Write(ReadOnlySpan<char>) with efficient
+            // implementations; for other writers TextWriter's base implementation rents and
+            // copies through ArrayPool, so they keep the original per-character writes.
+            if (target is StringWriter || target is StreamWriter)
+            {
+                target.Write(text.AsSpan(start, length));
+                return;
+            }
+#endif
             var end = start + length;
             for (var i = start; i < end; i++)
             {
                 target.Write(text[i]);
             }
-#else
-            target.Write(text.AsSpan(start, length));
-#endif
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/source/Handlebars/IO/HtmlEncoder.cs
+++ b/source/Handlebars/IO/HtmlEncoder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -12,28 +13,81 @@ namespace HandlebarsDotNet
     /// </summary>
     public class HtmlEncoder : ITextEncoder
     {
+        /*
+         * Escape set based on: https://github.com/handlebars-lang/handlebars.js/blob/master/lib/handlebars/utils.js
+         * As of 2021-12-20 / commit https://github.com/handlebars-lang/handlebars.js/commit/3fb331ef40ee1a8308dd83b8e5adbcd798d0adc9
+         */
+        private static readonly char[] EscapeChars = { '&', '<', '>', '"', '\'', '`', '=' };
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Encode(StringBuilder text, TextWriter target)
         {
             if(text == null || text.Length == 0) return;
-            
+
             EncodeImpl(new StringBuilderEnumerator(text), target);
         }
-        
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+
         public void Encode(string text, TextWriter target)
         {
             if(string.IsNullOrEmpty(text)) return;
-            
-            EncodeImpl(new StringEnumerator(text), target);
+
+            var index = text.IndexOfAny(EscapeChars);
+            if (index == -1)
+            {
+                // Fast path: nothing to escape, write the whole string at once
+                target.Write(text);
+                return;
+            }
+
+            var start = 0;
+            do
+            {
+                var runLength = index - start;
+                if (runLength != 0) WriteRun(text, start, runLength, target);
+                target.Write(GetEscapeSequence(text[index]));
+
+                start = index + 1;
+                index = start < text.Length ? text.IndexOfAny(EscapeChars, start) : -1;
+            } while (index != -1);
+
+            if (start < text.Length) WriteRun(text, start, text.Length - start, target);
         }
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Encode<T>(T text, TextWriter target) where T : IEnumerator<char>
         {
             if (text is null) return;
-            
+
             EncodeImpl(text, target);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void WriteRun(string text, int start, int length, TextWriter target)
+        {
+#if NETSTANDARD2_0
+            var end = start + length;
+            for (var i = start; i < end; i++)
+            {
+                target.Write(text[i]);
+            }
+#else
+            target.Write(text.AsSpan(start, length));
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static string GetEscapeSequence(char value)
+        {
+            switch (value)
+            {
+                case '&': return "&amp;";
+                case '<': return "&lt;";
+                case '>': return "&gt;";
+                case '"': return "&quot;";
+                case '\'': return "&#x27;";
+                case '`': return "&#x60;";
+                default: return "&#x3D;"; // '='
+            }
         }
 
         private static void EncodeImpl<T>(T text, TextWriter target) where T : IEnumerator<char>

--- a/source/Handlebars/IO/HtmlEncoder.cs
+++ b/source/Handlebars/IO/HtmlEncoder.cs
@@ -17,7 +17,9 @@ namespace HandlebarsDotNet
          * Escape set based on: https://github.com/handlebars-lang/handlebars.js/blob/master/lib/handlebars/utils.js
          * As of 2021-12-20 / commit https://github.com/handlebars-lang/handlebars.js/commit/3fb331ef40ee1a8308dd83b8e5adbcd798d0adc9
          */
-        private static readonly char[] EscapeChars = { '&', '<', '>', '"', '\'', '`', '=' };
+#if NET8_0_OR_GREATER
+        private static readonly System.Buffers.SearchValues<char> EscapeChars = System.Buffers.SearchValues.Create("&<>\"'`=");
+#endif
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Encode(StringBuilder text, TextWriter target)
@@ -31,7 +33,7 @@ namespace HandlebarsDotNet
         {
             if(string.IsNullOrEmpty(text)) return;
 
-            var index = text.IndexOfAny(EscapeChars);
+            var index = IndexOfEscapeChar(text, 0);
             if (index == -1)
             {
                 // Fast path: nothing to escape, write the whole string at once
@@ -47,10 +49,38 @@ namespace HandlebarsDotNet
                 target.Write(GetEscapeSequence(text[index]));
 
                 start = index + 1;
-                index = start < text.Length ? text.IndexOfAny(EscapeChars, start) : -1;
+                index = start < text.Length ? IndexOfEscapeChar(text, start) : -1;
             } while (index != -1);
 
             if (start < text.Length) WriteRun(text, start, text.Length - start, target);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int IndexOfEscapeChar(string text, int start)
+        {
+#if NET8_0_OR_GREATER
+            // SearchValues pre-computes the lookup structure once; string.IndexOfAny(char[])
+            // with more than 5 needles would rebuild a probabilistic map on every call.
+            var index = text.AsSpan(start).IndexOfAny(EscapeChars);
+            return index < 0 ? -1 : index + start;
+#else
+            for (var i = start; i < text.Length; i++)
+            {
+                switch (text[i])
+                {
+                    case '&':
+                    case '<':
+                    case '>':
+                    case '"':
+                    case '\'':
+                    case '`':
+                    case '=':
+                        return i;
+                }
+            }
+
+            return -1;
+#endif
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/source/Handlebars/IO/HtmlEncoder.cs
+++ b/source/Handlebars/IO/HtmlEncoder.cs
@@ -41,18 +41,11 @@ namespace HandlebarsDotNet
                 return;
             }
 
-            var start = 0;
-            do
-            {
-                var runLength = index - start;
-                if (runLength != 0) WriteRun(text, start, runLength, target);
-                target.Write(GetEscapeSequence(text[index]));
-
-                start = index + 1;
-                index = start < text.Length ? IndexOfEscapeChar(text, start) : -1;
-            } while (index != -1);
-
-            if (start < text.Length) WriteRun(text, start, text.Length - start, target);
+            // Bulk-write the clean prefix, then fall back to per-character encoding.
+            // Escape-dense content makes per-segment bulk writes counter-productive:
+            // the fixed cost of a span write outweighs a few Write(char) calls.
+            if (index != 0) WriteRun(text, 0, index, target);
+            EncodeImpl(new StringEnumerator(text, index), target);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -108,21 +101,6 @@ namespace HandlebarsDotNet
             for (var i = start; i < end; i++)
             {
                 target.Write(text[i]);
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static string GetEscapeSequence(char value)
-        {
-            switch (value)
-            {
-                case '&': return "&amp;";
-                case '<': return "&lt;";
-                case '>': return "&gt;";
-                case '"': return "&quot;";
-                case '\'': return "&#x27;";
-                case '`': return "&#x60;";
-                default: return "&#x3D;"; // '='
             }
         }
 

--- a/source/Handlebars/IO/HtmlEncoderLegacy.cs
+++ b/source/Handlebars/IO/HtmlEncoderLegacy.cs
@@ -1,4 +1,5 @@
-﻿using HandlebarsDotNet.StringUtils;
+using HandlebarsDotNet.StringUtils;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -24,12 +25,32 @@ namespace HandlebarsDotNet
             EncodeImpl(new StringBuilderEnumerator(text), target);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Encode(string text, TextWriter target)
         {
             if (string.IsNullOrEmpty(text)) return;
 
-            EncodeImpl(new StringEnumerator(text), target);
+            var length = text.Length;
+            var start = 0;
+            var anyEscaped = false;
+            for (var index = 0; index < length; index++)
+            {
+                var value = text[index];
+                if (!RequiresEscaping(value)) continue;
+
+                anyEscaped = true;
+                if (index != start) WriteRun(text, start, index - start, target);
+                WriteEscaped(value, target);
+                start = index + 1;
+            }
+
+            if (!anyEscaped)
+            {
+                // Fast path: nothing to escape, write the whole string at once
+                target.Write(text);
+                return;
+            }
+
+            if (start < length) WriteRun(text, start, length - start, target);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -38,6 +59,59 @@ namespace HandlebarsDotNet
             if (text is null) return;
 
             EncodeImpl(text, target);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool RequiresEscaping(char value)
+        {
+            switch (value)
+            {
+                case '"':
+                case '&':
+                case '<':
+                case '>':
+                    return true;
+                default:
+                    return value > 159;
+            }
+        }
+
+        private static void WriteEscaped(char value, TextWriter target)
+        {
+            switch (value)
+            {
+                case '"':
+                    target.Write("&quot;");
+                    break;
+                case '&':
+                    target.Write("&amp;");
+                    break;
+                case '<':
+                    target.Write("&lt;");
+                    break;
+                case '>':
+                    target.Write("&gt;");
+                    break;
+                default:
+                    target.Write("&#");
+                    target.Write((int)value);
+                    target.Write(";");
+                    break;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void WriteRun(string text, int start, int length, TextWriter target)
+        {
+#if NETSTANDARD2_0
+            var end = start + length;
+            for (var i = start; i < end; i++)
+            {
+                target.Write(text[i]);
+            }
+#else
+            target.Write(text.AsSpan(start, length));
+#endif
         }
 
         private static void EncodeImpl<T>(T text, TextWriter target) where T : IEnumerator<char>

--- a/source/Handlebars/IO/HtmlEncoderLegacy.cs
+++ b/source/Handlebars/IO/HtmlEncoderLegacy.cs
@@ -103,15 +103,21 @@ namespace HandlebarsDotNet
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void WriteRun(string text, int start, int length, TextWriter target)
         {
-#if NETSTANDARD2_0
+#if !NETSTANDARD2_0
+            // StringWriter and StreamWriter override Write(ReadOnlySpan<char>) with efficient
+            // implementations; for other writers TextWriter's base implementation rents and
+            // copies through ArrayPool, so they keep the original per-character writes.
+            if (target is StringWriter || target is StreamWriter)
+            {
+                target.Write(text.AsSpan(start, length));
+                return;
+            }
+#endif
             var end = start + length;
             for (var i = start; i < end; i++)
             {
                 target.Write(text[i]);
             }
-#else
-            target.Write(text.AsSpan(start, length));
-#endif
         }
 
         private static void EncodeImpl<T>(T text, TextWriter target) where T : IEnumerator<char>

--- a/source/Handlebars/IO/HtmlEncoderLegacy.cs
+++ b/source/Handlebars/IO/HtmlEncoderLegacy.cs
@@ -30,27 +30,19 @@ namespace HandlebarsDotNet
             if (string.IsNullOrEmpty(text)) return;
 
             var length = text.Length;
-            var start = 0;
-            var anyEscaped = false;
-            for (var index = 0; index < length; index++)
-            {
-                var value = text[index];
-                if (!RequiresEscaping(value)) continue;
+            var index = 0;
+            while (index < length && !RequiresEscaping(text[index])) index++;
 
-                anyEscaped = true;
-                if (index != start) WriteRun(text, start, index - start, target);
-                WriteEscaped(value, target);
-                start = index + 1;
-            }
-
-            if (!anyEscaped)
+            if (index == length)
             {
                 // Fast path: nothing to escape, write the whole string at once
                 target.Write(text);
                 return;
             }
 
-            if (start < length) WriteRun(text, start, length - start, target);
+            // Bulk-write the clean prefix, then fall back to per-character encoding.
+            if (index != 0) WriteRun(text, 0, index, target);
+            EncodeImpl(new StringEnumerator(text, index), target);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -73,30 +65,6 @@ namespace HandlebarsDotNet
                     return true;
                 default:
                     return value > 159;
-            }
-        }
-
-        private static void WriteEscaped(char value, TextWriter target)
-        {
-            switch (value)
-            {
-                case '"':
-                    target.Write("&quot;");
-                    break;
-                case '&':
-                    target.Write("&amp;");
-                    break;
-                case '<':
-                    target.Write("&lt;");
-                    break;
-                case '>':
-                    target.Write("&gt;");
-                    break;
-                default:
-                    target.Write("&#");
-                    target.Write((int)value);
-                    target.Write(";");
-                    break;
             }
         }
 

--- a/source/Handlebars/StringUtils/StringEnumerator.cs
+++ b/source/Handlebars/StringUtils/StringEnumerator.cs
@@ -18,6 +18,14 @@ namespace HandlebarsDotNet.StringUtils
             _length = _text.Length;
             _index = -1;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public StringEnumerator(string text, int start)
+        {
+            _text = text;
+            _length = _text.Length;
+            _index = start - 1;
+        }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool MoveNext() => ++_index < _length;


### PR DESCRIPTION
## Summary

Speeds up HTML encoding — the hot path every `{{expression}}` output goes through — by writing clean runs of text in bulk instead of one `TextWriter.Write(char)` virtual call per character.

**How it works:**

- Scan for the first character that needs escaping (`SearchValues<char>` on net8.0 — pre-computed lookup, vectorized; a plain scan loop on netstandard2.0/2.1).
- If nothing needs escaping (the common case for typical property values), write the whole string with a single `Write(string)` call.
- Otherwise, bulk-write the clean prefix and encode the remainder with the original per-character loop.
- Bulk prefix writes use `AsSpan()` only for `StringWriter`/`StreamWriter` (which override `Write(ReadOnlySpan<char>)` efficiently); other writers keep per-char behavior, because `TextWriter`'s base span implementation rents/copies via `ArrayPool` and can be slower than what it replaces.

Applied to both `HtmlEncoder` and `HtmlEncoderLegacy`. Encoded output is byte-for-byte identical; all 1837 tests pass.

**Dead ends measured and avoided** (why the implementation looks the way it does):

- `string.IndexOfAny(char[])` with 7 needles rebuilds a probabilistic character map on *every call* — it regressed short strings by 5–15% and escape-dense content by 45%. `SearchValues` fixes this on net8.0.
- Bulk-writing every clean segment *between* escapes regressed escape-dense content ~11%: the fixed cost of a span write outweighs a few `Write(char)` calls when segments are short. Hence prefix-only bulk writing.

## Benchmarks

MediumRun (LaunchCount=1, 15 iterations), Apple M4, .NET 10. Baseline is master @ 37ca7b9.
`RenderToString` is the new suite from #650 — it renders through the string-returning API (real `StringWriter`), where output cost is actually paid; the other suites render to `TextWriter.Null`.

| Benchmark | Case | master | This PR | Δ time |
|---|---|---:|---:|---:|
| RenderSimple | dictionary | 509.96 ns | 399.20 ns | **−21.7%** |
| RenderSimple | expando | 414.36 ns | 350.20 ns | **−15.5%** |
| RenderSimple | object | 856.85 ns | 752.40 ns | **−12.2%** |
| RenderList | N=10, dictionary | 2,420.21 ns | 2,033.00 ns | **−16.0%** |
| RenderList | N=10, object | 2,916.26 ns | 2,660.00 ns | **−8.8%** |
| RenderList | N=100, dictionary | 23.42 us | 19.06 us | **−18.6%** |
| RenderList | N=100, object | 27.48 us | 22.05 us | **−19.8%** |
| RenderList | N=1000, dictionary | 231.70 us | 194.39 us | **−16.1%** |
| RenderList | N=1000, object | 259.14 us | 213.59 us | **−17.6%** |
| RenderNested | dictionary, rows=5 | 5,413.42 ns | 4,979.00 ns | **−8.0%** |
| RenderNested | dictionary, rows=20 | 18.54 us | 17.54 us | **−5.4%** |
| RenderNested | object, rows=5 | 6,764.33 ns | 6,643.00 ns | −1.8% |
| RenderNested | object, rows=20 | 24.52 us | 23.94 us | −2.4% |
| RenderToString | clean | 13.95 us | 10.97 us | **−21.4%** |
| RenderToString | html (escape-dense) | 14.75 us | 14.43 us | −2.2% |

Neutral (within run-to-run noise), as expected:

- `LargeArray` (writes ints, not strings): −0.6% to −4.4%
- `EndToEnd` (helper-dominated): −1.4% / +2.2%
- `Execution.*` helper dispatch (unencoded `WriteSafeString`): all within ±2%
- Escape-dense content (`RenderToString/html`): measured twice, −2.2% and +8.1% — i.e. neutral within observed cross-run variance; the worst case trades nothing measurable for the ~20% typical-case win.

Allocations are unchanged in every suite (this change affects call patterns, not allocation).

> Note: includes the `RenderToString` benchmark suite commit (submitted separately as #650) so the numbers above are reproducible from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
