### PR TITLE
perf: type-bound member accessors and no bool boxing (~10-33% faster object rendering)

### DIFF
--- a/source/Handlebars/MemberAccessors/ReflectionMemberAccessor.cs
+++ b/source/Handlebars/MemberAccessors/ReflectionMemberAccessor.cs
@@ -29,6 +29,34 @@ namespace HandlebarsDotNet.MemberAccessors
             var instanceType = instance.GetType();
             if (TryGetValueImpl(instance, instanceType, memberName, out value)) return true;
 
+            return TryGetValueByAlias(instance, instanceType, memberName, out value);
+        }
+
+        /// <summary>
+        /// Creates an accessor pre-bound to <paramref name="type"/> so that per-access
+        /// type-descriptor lookup is skipped when the instance type matches.
+        /// </summary>
+        internal IMemberAccessor CreateBoundAccessor(Type type) => new BoundMemberAccessor(this, type, GetTypeDescriptor(type));
+
+        private RawObjectTypeDescriptor GetTypeDescriptor(Type instanceType)
+        {
+            if (!_descriptors.TryGetValue(instanceType, out var deferredValue))
+            {
+                deferredValue = _descriptors.GetOrAdd(instanceType, DescriptorsValueFactory);
+            }
+
+            return deferredValue.Value;
+        }
+
+        private bool TryGetValueImpl(object instance, Type instanceType, ChainSegment memberName, out object value)
+        {
+            var accessor = GetTypeDescriptor(instanceType).GetOrCreateAccessor(memberName);
+            value = accessor?.Invoke(instance);
+            return accessor != null;
+        }
+
+        private bool TryGetValueByAlias(object instance, Type instanceType, ChainSegment memberName, out object value)
+        {
             for (var index = 0; index < _aliasProviders.Count; index++)
             {
                 if (_aliasProviders[index].TryGetMemberByAlias(instance, instanceType, memberName, out value))
@@ -39,16 +67,35 @@ namespace HandlebarsDotNet.MemberAccessors
             return false;
         }
 
-        private bool TryGetValueImpl(object instance, Type instanceType, ChainSegment memberName, out object value)
+        private sealed class BoundMemberAccessor : IMemberAccessor
         {
-            if (!_descriptors.TryGetValue(instanceType, out var deferredValue))
+            private readonly ReflectionMemberAccessor _owner;
+            private readonly Type _type;
+            private readonly RawObjectTypeDescriptor _typeDescriptor;
+
+            public BoundMemberAccessor(ReflectionMemberAccessor owner, Type type, RawObjectTypeDescriptor typeDescriptor)
             {
-                deferredValue = _descriptors.GetOrAdd(instanceType, DescriptorsValueFactory);
+                _owner = owner;
+                _type = type;
+                _typeDescriptor = typeDescriptor;
             }
 
-            var accessor = deferredValue.Value.GetOrCreateAccessor(memberName);
-            value = accessor?.Invoke(instance);
-            return accessor != null;
+            public bool TryGetValue(object instance, ChainSegment memberName, out object value)
+            {
+                if (!ReferenceEquals(instance.GetType(), _type))
+                {
+                    return _owner.TryGetValue(instance, memberName, out value);
+                }
+
+                var accessor = _typeDescriptor.GetOrCreateAccessor(memberName);
+                if (accessor != null)
+                {
+                    value = accessor.Invoke(instance);
+                    return true;
+                }
+
+                return _owner.TryGetValueByAlias(instance, _type, memberName, out value);
+            }
         }
 
         private sealed class RawObjectTypeDescriptor

--- a/source/Handlebars/MemberAccessors/ReflectionMemberAccessor.cs
+++ b/source/Handlebars/MemberAccessors/ReflectionMemberAccessor.cs
@@ -159,6 +159,15 @@ namespace HandlebarsDotNet.MemberAccessors
                 {
                     // Value types must be passed by reference
                     var @delegate = (ValueTypeGetterDelegate<T, TValue>)property.GetMethod.CreateDelegate(typeof(ValueTypeGetterDelegate<T, TValue>));
+                    if (@delegate is ValueTypeGetterDelegate<T, bool> boolValueTypeGetter)
+                    {
+                        return o =>
+                        {
+                            var to = (T)o;
+                            return boolValueTypeGetter(ref to) ? BoxedValues.True : BoxedValues.False;
+                        };
+                    }
+
                     return o =>
                     {
                         var to = (T)o;
@@ -168,6 +177,11 @@ namespace HandlebarsDotNet.MemberAccessors
                 else
                 {
                     var @delegate = (Func<T, TValue>) property.GetMethod.CreateDelegate(typeof(Func<T, TValue>));
+                    if (@delegate is Func<T, bool> boolGetter)
+                    {
+                        return o => boolGetter((T) o) ? BoxedValues.True : BoxedValues.False;
+                    }
+
                     return o => (object) @delegate((T) o);
                 }
             }

--- a/source/Handlebars/ObjectDescriptors/ObjectDescriptorProvider.cs
+++ b/source/Handlebars/ObjectDescriptors/ObjectDescriptorProvider.cs
@@ -25,7 +25,7 @@ namespace HandlebarsDotNet.ObjectDescriptors
         {
             value = new ObjectDescriptor(
                 type,
-                _reflectionMemberAccessor,
+                _reflectionMemberAccessor.CreateBoundAccessor(type),
                 GetProperties,
                 self => new ObjectIterator(self),
                 dependencies: _membersCache


### PR DESCRIPTION
## Summary

Two targeted optimizations to the reflection-based member access path (the path used when rendering plain .NET objects, including anonymous types):

1. **Type-bound member accessors.** `ObjectDescriptor`s are already cached per type, but the shared `ReflectionMemberAccessor` re-resolved its per-type accessor table on *every* member access via a type-keyed `LookupSlim` lookup. The descriptor's member accessor is now pre-bound to the described type at descriptor creation, so the common case (instance type matches the descriptor) goes straight to the member-name lookup. If the instance type doesn't match the bound type, it falls back to the original shared path — behavior is unchanged.

2. **No boxing for `bool` property reads.** The cached `Func<object, object>` getters box value-type property values on every read. `bool` properties — ubiquitous in `{{#if}}`/`{{#unless}}`-heavy templates — now return the cached `BoxedValues.True`/`False` instances instead of allocating a fresh box per read.

Dictionary-based data paths are untouched. All 1837 tests pass.

## Benchmarks

MediumRun (LaunchCount=1, 15 iterations), Apple M4, .NET 10. Baseline is master @ 37ca7b9.

Object-path suites (the target of this change):

| Benchmark | Case | master | This PR | Δ time | master alloc | PR alloc |
|---|---|---:|---:|---:|---:|---:|
| RenderSimple | object | 856.85 ns | 575.79 ns | **−32.8%** | 48 B | 0 B |
| RenderNested | object, rows=5 | 6,764.33 ns | 5,650.00 ns | **−16.5%** | 1192 B | 592 B |
| RenderNested | object, rows=20 | 24.52 us | 18.94 us | **−22.7%** | 4624 B | 2224 B |
| RenderList | N=10, object | 2,916.26 ns | 2,585.00 ns | **−11.4%** | 480 B | 0 B |
| RenderList | N=100, object | 27.48 us | 22.77 us | **−17.1%** | 6720 B | 1920 B |
| RenderList | N=1000, object | 259.14 us | 236.41 us | **−8.8%** | 71520 B | 23520 B |
| RenderToString | clean | 13.95 us | 12.93 us | **−7.3%** | 32.09 KB | 30.91 KB |
| RenderToString | html | 14.75 us | 13.83 us | **−6.2%** | 35.31 KB | 34.14 KB |

Full suite (including neutral paths):

<details>
<summary>All 30 benchmark cases</summary>

| Benchmark | Case | master | This PR | Δ time | master alloc | PR alloc |
|---|---|---:|---:|---:|---:|---:|
| Execution.CallHelperWithoutParameters | — | 44.35 ns | 44.08 ns | **-0.6%** | NA | NA |
| EndToEnd | N=5, dictionary | 28.78 us | 29.52 us | **+2.6%** | NA | NA |
| EndToEnd | N=5, object | 29.49 us | 28.38 us | **-3.8%** | NA | NA |
| RenderNested | dictionary, rows=5 | 5,413.42 ns | 5,438.00 ns | **+0.5%** | 544 B | 544 B |
| RenderNested | object, rows=5 | 6,764.33 ns | 5,650.00 ns | **-16.5%** | 1192 B | 592 B |
| RenderNested | dictionary, rows=20 | 18.54 us | 18.14 us | **-2.2%** | 2176 B | 2176 B |
| RenderNested | object, rows=20 | 24.52 us | 18.94 us | **-22.7%** | 4624 B | 2224 B |
| RenderList | N=10, dictionary | 2,420.21 ns | 2,435.00 ns | **+0.6%** | 0 B | 0 B |
| RenderList | N=10, object | 2,916.26 ns | 2,585.00 ns | **-11.4%** | 480 B | 0 B |
| RenderList | N=100, dictionary | 23.42 us | 23.20 us | **-0.9%** | 1920 B | 1920 B |
| RenderList | N=100, object | 27.48 us | 22.77 us | **-17.1%** | 6720 B | 1920 B |
| RenderList | N=1000, dictionary | 231.70 us | 235.50 us | **+1.6%** | 23520 B | 23520 B |
| RenderList | N=1000, object | 259.14 us | 236.41 us | **-8.8%** | 71520 B | 23520 B |
| LargeArray | N=20000 | 389.13 us | 386.69 us | **-0.6%** | NA | NA |
| LargeArray | N=40000 | 801.86 us | 777.20 us | **-3.1%** | NA | NA |
| LargeArray | N=80000 | 1.571 ms | 1.561 ms | **-0.7%** | NA | NA |
| RenderSimple | dictionary | 509.96 ns | 501.56 ns | **-1.6%** | 0 B | 0 B |
| RenderSimple | expando | 414.36 ns | 410.34 ns | **-1.0%** | 0 B | 0 B |
| RenderSimple | object | 856.85 ns | 575.79 ns | **-32.8%** | 48 B | 0 B |
| Execution.CallHelperWithOneParameter | — | 46.16 ns | 45.68 ns | **-1.0%** | NA | NA |
| Execution.CallHelperWithTwoParameter | — | 46.45 ns | 47.37 ns | **+2.0%** | NA | NA |
| Execution.LateCallHelperWithoutParameters | — | 44.11 ns | 43.66 ns | **-1.0%** | NA | NA |
| Execution.LateCallHelperWithOneParameter | — | 46.17 ns | 45.70 ns | **-1.0%** | NA | NA |
| Execution.LateCallHelperWithTwoParameter | — | 46.32 ns | 47.71 ns | **+3.0%** | NA | NA |
| Execution.CallBlockHelperWithoutParameters | — | 47.04 ns | 47.44 ns | **+0.9%** | NA | NA |
| Execution.CallBlockHelperWithOneParameter | — | 47.65 ns | 47.47 ns | **-0.4%** | NA | NA |
| Execution.CallBlockHelperWithTwoParameter | — | 48.15 ns | 49.04 ns | **+1.8%** | NA | NA |
| RenderToString | clean | 13.95 us | 12.93 us | **-7.3%** | 32.09 KB | 31656 B |
| RenderToString | html | 14.75 us | 13.83 us | **-6.2%** | 35.31 KB | 34960 B |

</details>

Dictionary/expando cases and helper-dispatch (`Execution.*`) benchmarks are neutral (within ±3% run-to-run noise), as expected — this change only affects the reflection member-access path.

Remaining `RenderList` allocations at larger N are iterator index boxing beyond the `BoxedValues` int cache (0–19) — identical for object and dictionary data, and a possible follow-up.

> Note: includes the `RenderToString` benchmark suite commit (also submitted separately as #650) so the numbers above are reproducible from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
