### PR TITLE
perf: enlarge BoxedValues int cache to eliminate iterator index boxing

### DIFF
--- a/source/Handlebars.Benchmark/EndToEnd.cs
+++ b/source/Handlebars.Benchmark/EndToEnd.cs
@@ -8,6 +8,7 @@ using HandlebarsDotNet.PathStructure;
 
 namespace HandlebarsNet.Benchmark
 {
+    [MemoryDiagnoser]
     public class EndToEnd
     {
         private object? _data;

--- a/source/Handlebars.Benchmark/LargeArray.cs
+++ b/source/Handlebars.Benchmark/LargeArray.cs
@@ -7,6 +7,7 @@ using HandlebarsDotNet;
 
 namespace HandlebarsNet.Benchmark
 {
+    [MemoryDiagnoser]
     public class LargeArray
     {
         private object _data = null!; // -> Setup()

--- a/source/Handlebars/Runtime/BoxedValues.cs
+++ b/source/Handlebars/Runtime/BoxedValues.cs
@@ -11,7 +11,10 @@ namespace HandlebarsDotNet.Runtime
     /// </summary>
     public static class BoxedValues
     {
-        private const int BoxedIntegersCount = 20;
+        // Covers iterator indexes for effectively all template loops. The cache is
+        // ~32KB of process-lifetime statics (1024 boxes + the array), traded against
+        // a 24-byte allocation per iteration index >= the cache size on every render.
+        private const int BoxedIntegersCount = 1024;
         private static readonly object[] BoxedIntegers = new object[BoxedIntegersCount];
 
         static BoxedValues()


### PR DESCRIPTION
## Summary

Follow-up to #652. Iterators box the per-item index through `BoxedValues.Int` on every iteration; indexes beyond the cache (previously 0–19) allocate a fresh 24-byte box each time. After #651/#652 removed the larger allocation sources, this was the dominant remaining allocation in list rendering — e.g. 23.5KB per render of a 1000-item `{{#each}}`, identical for object and dictionary data.

- Enlarges the cache from 20 to 1024 boxed integers (~32KB of process-lifetime statics), covering effectively all template loops.
- Also enables `MemoryDiagnoser` on the `LargeArray` and `EndToEnd` suites so allocation deltas are visible there (separate commit).

All 1840 tests pass.

## Benchmarks

MediumRun (LaunchCount=1, 15 iterations), Apple M4, .NET 10. Baseline is current master @ 9ee2d48 (i.e. *after* #651/#652) plus the MemoryDiagnoser commit.

| Benchmark | Case | master alloc | This PR | Δ time |
|---|---|---:|---:|---:|
| RenderList | N=100, dictionary | 1,920 B | **0 B** | +0.8% |
| RenderList | N=100, object | 1,920 B | **0 B** | +0.0% |
| RenderList | N=1000, dictionary | 23,520 B | **0 B** | +0.4% |
| RenderList | N=1000, object | 23,520 B | **0 B** | +3.1% |
| RenderList | N=10, both | 0 B | 0 B | −6.2% / +0.7% |
| RenderToString | clean / html | 31,656 / 34,960 B | 30,936 / 34,240 B | −0.8% / +2.2% |
| LargeArray | N=20000 | 959,521 B | 935,425 B | −1.0% |
| LargeArray | N=40000 | 1,919,521 B | 1,895,425 B | −9.1% |
| LargeArray | N=80000 | 3,839,522 B | 3,815,424 B | +2.3% |
| RenderNested | all 4 cases | unchanged | unchanged | −4.1% to +0.4% |
| EndToEnd | both | 744 B | 744 B | −3.0% / −1.5% |

Time deltas are all within the ±3% cross-run noise band observed on this machine (the −9.1% and −6.2% outliers included) — this change is about allocation, not speed.

`LargeArray` drops exactly the 1,004 newly-cached index boxes (~24KB/render); its remaining megabytes are the `List<int>` *values* being boxed when read as `object` — a separate mechanism, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
