### PR TITLE
Use NotNullWhen(true) instead of MaybeNullWhen(false) for concrete-type Try-methods

### DIFF
--- a/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/BlockAccumulatorContext.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/BlockAccumulatorContext.cs
@@ -125,7 +125,7 @@ namespace HandlebarsDotNet.Compiler
             };
         }
 
-        private static bool IsDetachedClosingElement(Expression item, Expression? parentItem, [MaybeNullWhen(false)] out string closingElement)
+        private static bool IsDetachedClosingElement(Expression item, Expression? parentItem, [NotNullWhen(true)] out string? closingElement)
         {
             closingElement = null;
 

--- a/source/Handlebars/Extensions/TypeExtensions.cs
+++ b/source/Handlebars/Extensions/TypeExtensions.cs
@@ -6,7 +6,7 @@ namespace HandlebarsDotNet
 {
     internal static class TypeExtensions
     {
-        public static bool IsAssignableToGenericType(this Type givenType, Type genericType, [MaybeNullWhen(false)] out Type resolvedType)
+        public static bool IsAssignableToGenericType(this Type givenType, Type genericType, [NotNullWhen(true)] out Type? resolvedType)
         {
             while (true)
             {

--- a/source/Handlebars/Helpers/IHelperResolver.cs
+++ b/source/Handlebars/Helpers/IHelperResolver.cs
@@ -16,7 +16,7 @@ namespace HandlebarsDotNet.Helpers
         /// <param name="targetType"></param>
         /// <param name="helper"></param>
         /// <returns></returns>
-        bool TryResolveHelper(PathInfo name, Type? targetType, [MaybeNullWhen(false)] out IHelperDescriptor<HelperOptions> helper);
+        bool TryResolveHelper(PathInfo name, Type? targetType, [NotNullWhen(true)] out IHelperDescriptor<HelperOptions>? helper);
 
         /// <summary>
         /// Resolves <see cref="HandlebarsBlockHelper"/>
@@ -24,6 +24,6 @@ namespace HandlebarsDotNet.Helpers
         /// <param name="name"></param>
         /// <param name="helper"></param>
         /// <returns></returns>
-        bool TryResolveBlockHelper(PathInfo name, [MaybeNullWhen(false)] out IHelperDescriptor<BlockHelperOptions> helper);
+        bool TryResolveBlockHelper(PathInfo name, [NotNullWhen(true)] out IHelperDescriptor<BlockHelperOptions>? helper);
     }
 }

--- a/source/Handlebars/IO/Formatters/CollectionFormatterProvider.cs
+++ b/source/Handlebars/IO/Formatters/CollectionFormatterProvider.cs
@@ -11,7 +11,7 @@ namespace HandlebarsDotNet.IO
         private static readonly Type CollectionFormatterType = typeof(CollectionFormatter<,>);
         private static readonly Type CollectionType = typeof(ICollection<>);
 
-        public bool TryCreateFormatter(Type type, [MaybeNullWhen(false)] out IFormatter formatter)
+        public bool TryCreateFormatter(Type type, [NotNullWhen(true)] out IFormatter? formatter)
         {
             if (!type.GetTypeInfo().IsClass || !type.IsAssignableToGenericType(CollectionType, out var genericType))
             {

--- a/source/Handlebars/IO/Formatters/DefaultFormatterProvider.cs
+++ b/source/Handlebars/IO/Formatters/DefaultFormatterProvider.cs
@@ -27,7 +27,7 @@ namespace HandlebarsDotNet.IO
 
         private static readonly DefaultObjectFormatter DefaultObjectFormatter = new DefaultObjectFormatter();
         
-        public bool TryCreateFormatter(Type type, [MaybeNullWhen(false)] out IFormatter formatter)
+        public bool TryCreateFormatter(Type type, [NotNullWhen(true)] out IFormatter? formatter)
         {
             if (!Formatters.TryGetValue(type, out formatter))
             {

--- a/source/Handlebars/IO/Formatters/FormatterProvider.cs
+++ b/source/Handlebars/IO/Formatters/FormatterProvider.cs
@@ -68,7 +68,7 @@ namespace HandlebarsDotNet.IO
             return this;
         }
         
-        public bool TryCreateFormatter(Type type, [MaybeNullWhen(false)] out IFormatter formatter)
+        public bool TryCreateFormatter(Type type, [NotNullWhen(true)] out IFormatter? formatter)
         {
             formatter = _formatters.GetOrAdd(type, ValueFactory, _formatterProviders).Value;
             return formatter != null;

--- a/source/Handlebars/IO/Formatters/IFormatterProvider.cs
+++ b/source/Handlebars/IO/Formatters/IFormatterProvider.cs
@@ -5,6 +5,6 @@ namespace HandlebarsDotNet.IO
 {
     public interface IFormatterProvider
     {
-        bool TryCreateFormatter(Type type, [MaybeNullWhen(false)] out IFormatter formatter);
+        bool TryCreateFormatter(Type type, [NotNullWhen(true)] out IFormatter? formatter);
     }
 }

--- a/source/Handlebars/IO/Formatters/ReadOnlyCollectionFormatterProvider.cs
+++ b/source/Handlebars/IO/Formatters/ReadOnlyCollectionFormatterProvider.cs
@@ -11,7 +11,7 @@ namespace HandlebarsDotNet.IO
         private static readonly Type CollectionFormatterType = typeof(ReadOnlyCollectionFormatter<,>);
         private static readonly Type CollectionType = typeof(IReadOnlyCollection<>);
 
-        public bool TryCreateFormatter(Type type, [MaybeNullWhen(false)] out IFormatter formatter)
+        public bool TryCreateFormatter(Type type, [NotNullWhen(true)] out IFormatter? formatter)
         {
             if (!type.GetTypeInfo().IsClass || !type.IsAssignableToGenericType(CollectionType, out var genericType))
             {

--- a/source/Handlebars/IO/Formatters/UndefinedFormatter.cs
+++ b/source/Handlebars/IO/Formatters/UndefinedFormatter.cs
@@ -9,7 +9,7 @@ namespace HandlebarsDotNet.IO
 
         public string? FormatString { get; set; }
         
-        public bool TryCreateFormatter(Type type, [MaybeNullWhen(false)] out IFormatter formatter)
+        public bool TryCreateFormatter(Type type, [NotNullWhen(true)] out IFormatter? formatter)
         {
             if (type != typeof(UndefinedBindingResult))
             {

--- a/source/Handlebars/LayoutViewModel.cs
+++ b/source/Handlebars/LayoutViewModel.cs
@@ -49,7 +49,7 @@ namespace HandlebarsDotNet
                 );
             }
 
-            public bool TryGetDescriptor(Type type, [MaybeNullWhen(false)] out ObjectDescriptor value)
+            public bool TryGetDescriptor(Type type, [NotNullWhen(true)] out ObjectDescriptor? value)
             {
                 if (type != Type)
                 {

--- a/source/Handlebars/ObjectDescriptors/DictionaryObjectDescriptor.cs
+++ b/source/Handlebars/ObjectDescriptors/DictionaryObjectDescriptor.cs
@@ -19,7 +19,7 @@ namespace HandlebarsDotNet.ObjectDescriptors
         
         private static readonly Func<ObjectDescriptor, object, IEnumerable> GetProperties = (descriptor, arg) => ((IDictionary) arg).Keys;
 
-        public bool TryGetDescriptor(Type type, [MaybeNullWhen(false)] out ObjectDescriptor value)
+        public bool TryGetDescriptor(Type type, [NotNullWhen(true)] out ObjectDescriptor? value)
         {
             if (!Type.IsAssignableFrom(type))
             {

--- a/source/Handlebars/ObjectDescriptors/DynamicObjectDescriptor.cs
+++ b/source/Handlebars/ObjectDescriptors/DynamicObjectDescriptor.cs
@@ -34,7 +34,7 @@ namespace HandlebarsDotNet.ObjectDescriptors
             _objectDescriptorProvider = objectDescriptorProvider;
         }
         
-        public bool TryGetDescriptor(Type type, [MaybeNullWhen(false)] out ObjectDescriptor value)
+        public bool TryGetDescriptor(Type type, [NotNullWhen(true)] out ObjectDescriptor? value)
         {
             if (!Type.IsAssignableFrom(type))
             {

--- a/source/Handlebars/ObjectDescriptors/EnumerableObjectDescriptor.cs
+++ b/source/Handlebars/ObjectDescriptors/EnumerableObjectDescriptor.cs
@@ -57,7 +57,7 @@ namespace HandlebarsDotNet.ObjectDescriptors
             _descriptorProvider = descriptorProvider;
         }
         
-        public bool TryGetDescriptor(Type type, [MaybeNullWhen(false)] out ObjectDescriptor value)
+        public bool TryGetDescriptor(Type type, [NotNullWhen(true)] out ObjectDescriptor? value)
         {
             if (!(type != StringType && Type.IsAssignableFrom(type)))
             {
@@ -86,7 +86,7 @@ namespace HandlebarsDotNet.ObjectDescriptors
                    || TryCreateDescriptor(type, typeof(IEnumerable), parameters, NonGenericEnumerableObjectDescriptorFactoryMethodInfo, out value);
         }
 
-        private static bool TryCreateArrayDescriptor(Type type, object[] parameters, [MaybeNullWhen(false)] out ObjectDescriptor value)
+        private static bool TryCreateArrayDescriptor(Type type, object[] parameters, [NotNullWhen(true)] out ObjectDescriptor? value)
         {
             if (!type.IsArray)
             {
@@ -109,7 +109,7 @@ namespace HandlebarsDotNet.ObjectDescriptors
             return true;
         }
 
-        private static bool TryCreateDescriptorFromOpenGeneric(Type type, Type openGenericType, object[] parameters, MethodInfo method, [MaybeNullWhen(false)] out ObjectDescriptor descriptor)
+        private static bool TryCreateDescriptorFromOpenGeneric(Type type, Type openGenericType, object[] parameters, MethodInfo method, [NotNullWhen(true)] out ObjectDescriptor? descriptor)
         {
             if (type.IsAssignableToGenericType(openGenericType, out var genericType))
             {
@@ -124,7 +124,7 @@ namespace HandlebarsDotNet.ObjectDescriptors
             return false;
         }
         
-        private static bool TryCreateDescriptor(Type type, Type targetType, object[] parameters, MethodInfo method, [MaybeNullWhen(false)] out ObjectDescriptor descriptor)
+        private static bool TryCreateDescriptor(Type type, Type targetType, object[] parameters, MethodInfo method, [NotNullWhen(true)] out ObjectDescriptor? descriptor)
         {
             if (targetType.IsAssignableFrom(type))
             {

--- a/source/Handlebars/ObjectDescriptors/GenericDictionaryObjectDescriptorProvider.cs
+++ b/source/Handlebars/ObjectDescriptors/GenericDictionaryObjectDescriptorProvider.cs
@@ -21,7 +21,7 @@ namespace HandlebarsDotNet.ObjectDescriptors
         
         private readonly LookupSlim<Type, DeferredValue<Type, Type?>, ReferenceEqualityComparer<Type>> _typeCache = new LookupSlim<Type, DeferredValue<Type, Type?>, ReferenceEqualityComparer<Type>>(new ReferenceEqualityComparer<Type>());
         
-        public bool TryGetDescriptor(Type type, [MaybeNullWhen(false)] out ObjectDescriptor value)
+        public bool TryGetDescriptor(Type type, [NotNullWhen(true)] out ObjectDescriptor? value)
         {
             var interfaceType = _typeCache.GetOrAdd(type, InterfaceTypeValueFactory).Value;
             if (interfaceType == null)

--- a/source/Handlebars/ObjectDescriptors/IObjectDescriptorProvider.cs
+++ b/source/Handlebars/ObjectDescriptors/IObjectDescriptorProvider.cs
@@ -13,6 +13,6 @@ namespace HandlebarsDotNet.ObjectDescriptors
         /// </summary>
         /// <param name="type"></param>
         /// <param name="value"></param>
-        bool TryGetDescriptor(Type type, [MaybeNullWhen(false)] out ObjectDescriptor value);
+        bool TryGetDescriptor(Type type, [NotNullWhen(true)] out ObjectDescriptor? value);
     }
 }

--- a/source/Handlebars/ObjectDescriptors/ObjectAccessor.cs
+++ b/source/Handlebars/ObjectDescriptors/ObjectAccessor.cs
@@ -26,14 +26,15 @@ namespace HandlebarsDotNet
         public ObjectAccessor(object? data)
         {
             _data = data;
-            if (data == null || !ObjectDescriptorFactory.Current!.TryGetDescriptor(data.GetType(), out _descriptor))
+            if (data == null || !ObjectDescriptorFactory.Current!.TryGetDescriptor(data.GetType(), out var descriptor))
             {
-                _descriptor = ObjectDescriptor.Empty!;
+                _descriptor = ObjectDescriptor.Empty;
                 _memberAccessor = null;
             }
             else
             {
-                _memberAccessor = _descriptor.MemberAccessor;   
+                _descriptor = descriptor;
+                _memberAccessor = _descriptor.MemberAccessor;
             }
         }
 

--- a/source/Handlebars/ObjectDescriptors/ObjectDescriptor.cs
+++ b/source/Handlebars/ObjectDescriptors/ObjectDescriptor.cs
@@ -30,20 +30,20 @@ namespace HandlebarsDotNet.ObjectDescriptors
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryCreate(object? from, out ObjectDescriptor descriptor)
+        public static bool TryCreate(object? from, [NotNullWhen(true)] out ObjectDescriptor? descriptor)
         {
             return TryCreate(from?.GetType(), out descriptor);
         }
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryCreate(Type? @from, out ObjectDescriptor descriptor)
+        public static bool TryCreate(Type? @from, [NotNullWhen(true)] out ObjectDescriptor? descriptor)
         {
             if (from == null)
             {
                 descriptor = Empty;
                 return false;
             }
-            
+
             return ObjectDescriptorFactory.Current!.TryGetDescriptor(from, out descriptor);
         }
 

--- a/source/Handlebars/ObjectDescriptors/ObjectDescriptorFactory.cs
+++ b/source/Handlebars/ObjectDescriptors/ObjectDescriptorFactory.cs
@@ -56,7 +56,7 @@ namespace HandlebarsDotNet.ObjectDescriptors
             return this;
         }
         
-        public bool TryGetDescriptor(Type type, out ObjectDescriptor value)
+        public bool TryGetDescriptor(Type type, [NotNullWhen(true)] out ObjectDescriptor? value)
         {
             value = _descriptorsCache.GetOrAdd(type, ValueFactory, _providers).Value;
             return !ReferenceEquals(value, ObjectDescriptor.Empty);

--- a/source/Handlebars/ObjectDescriptors/ObjectDescriptorProvider.cs
+++ b/source/Handlebars/ObjectDescriptors/ObjectDescriptorProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using HandlebarsDotNet.Collections;
@@ -21,7 +22,7 @@ namespace HandlebarsDotNet.ObjectDescriptors
             _reflectionMemberAccessor = new ReflectionMemberAccessor(aliasProviders);
         }
         
-        public bool TryGetDescriptor(Type type, out ObjectDescriptor value)
+        public bool TryGetDescriptor(Type type, [NotNullWhen(true)] out ObjectDescriptor? value)
         {
             value = new ObjectDescriptor(
                 type,

--- a/source/Handlebars/ObjectDescriptors/ReadOnlyGenericDictionaryObjectDescriptorProvider.cs
+++ b/source/Handlebars/ObjectDescriptors/ReadOnlyGenericDictionaryObjectDescriptorProvider.cs
@@ -21,7 +21,7 @@ namespace HandlebarsDotNet.ObjectDescriptors
         
         private readonly LookupSlim<Type, DeferredValue<Type, Type?>, ReferenceEqualityComparer<Type>> _typeCache = new LookupSlim<Type, DeferredValue<Type, Type?>, ReferenceEqualityComparer<Type>>(new ReferenceEqualityComparer<Type>());
         
-        public bool TryGetDescriptor(Type type, [MaybeNullWhen(false)] out ObjectDescriptor value)
+        public bool TryGetDescriptor(Type type, [NotNullWhen(true)] out ObjectDescriptor? value)
         {
             var interfaceType = _typeCache.GetOrAdd(type, InterfaceTypeValueFactory).Value;
             if (interfaceType == null)

--- a/source/Handlebars/ObjectDescriptors/ReadOnlyStringDictionaryObjectDescriptorProvider.cs
+++ b/source/Handlebars/ObjectDescriptors/ReadOnlyStringDictionaryObjectDescriptorProvider.cs
@@ -21,7 +21,7 @@ namespace HandlebarsDotNet.ObjectDescriptors
 
         private readonly LookupSlim<Type, DeferredValue<Type, Type?>, ReferenceEqualityComparer<Type>> _typeCache = new LookupSlim<Type, DeferredValue<Type, Type?>, ReferenceEqualityComparer<Type>>(new ReferenceEqualityComparer<Type>());
 
-        public bool TryGetDescriptor(Type type, [MaybeNullWhen(false)] out ObjectDescriptor value)
+        public bool TryGetDescriptor(Type type, [NotNullWhen(true)] out ObjectDescriptor? value)
         {
             var interfaceType = _typeCache.GetOrAdd(type, InterfaceTypeValueFactory).Value;
             if (interfaceType == null)

--- a/source/Handlebars/ObjectDescriptors/StringDictionaryObjectDescriptorProvider.cs
+++ b/source/Handlebars/ObjectDescriptors/StringDictionaryObjectDescriptorProvider.cs
@@ -21,7 +21,7 @@ namespace HandlebarsDotNet.ObjectDescriptors
 
         private readonly LookupSlim<Type, DeferredValue<Type, Type?>, ReferenceEqualityComparer<Type>> _typeCache = new LookupSlim<Type, DeferredValue<Type, Type?>, ReferenceEqualityComparer<Type>>(new ReferenceEqualityComparer<Type>());
 
-        public bool TryGetDescriptor(Type type, [MaybeNullWhen(false)] out ObjectDescriptor value)
+        public bool TryGetDescriptor(Type type, [NotNullWhen(true)] out ObjectDescriptor? value)
         {
             var interfaceType = _typeCache.GetOrAdd(type, InterfaceTypeValueFactory).Value;
             if (interfaceType == null)


### PR DESCRIPTION
## Summary

PR #642 annotated *all* `Try*` out-parameters with `[MaybeNullWhen(false)] out T value` (non-nullable `T`), regardless of whether `T` was an unconstrained generic type parameter or a concrete reference type. That pattern is only correct for the generic case (mirroring `Dictionary<TKey,TValue>.TryGetValue`, which can't write `TValue?` without a `class` constraint). For concrete reference types, the BCL's own convention (e.g. `Uri.TryCreate`) is `[NotNullWhen(true)] out T?` - which also gives a stronger compiler guarantee: dereferencing the out value without checking the return value first now correctly warns, whereas `MaybeNullWhen(false)` on a non-nullable `T` silently allowed it.

This is a compile-time-only change (nullable annotations erase to metadata, not IL), so it's not binary breaking, and normal `if (TryX(..., out var x))` call sites are unaffected.

- `IHelperResolver.TryResolveHelper` / `TryResolveBlockHelper`
- `IObjectDescriptorProvider.TryGetDescriptor` and all implementers (`ObjectDescriptorProvider`, `ObjectDescriptorFactory`, `LayoutViewModel.DescriptorProvider`, the dictionary/enumerable/dynamic descriptor providers)
- `ObjectDescriptor.TryCreate` (both overloads)
- `IFormatterProvider.TryCreateFormatter` and all implementers
- `TypeExtensions.IsAssignableToGenericType`
- `BlockAccumulatorContext.IsDetachedClosingElement`

Left unchanged: the generic-`TValue` collection Try-methods (`LookupSlim`, `DictionarySlim`, `FixedSizeDictionary`, `CascadeIndex`, `ObservableIndex`) - these correctly mirror the BCL's own generic pattern already.

Fixes #654

## Test plan

- [x] `dotnet build` across all target frameworks (netstandard1.3/2.0/2.1, net6.0, net8.0) - 0 errors, no new warnings introduced (verified via clean-rebuild diff against master)
- [x] `dotnet test` - 1867/1867 passing