### PR TITLE
fix: resolve properties backed by default interface members

### DIFF
--- a/source/Handlebars.Test/IssueTests.cs
+++ b/source/Handlebars.Test/IssueTests.cs
@@ -1220,6 +1220,56 @@ namespace HandlebarsDotNet.Test
             Assert.Equal("D", template(new { value = "z" }));
         }
 
+        public interface Issue601_IBaseData
+        {
+            DateTime DateTimeUtc { get; }
+        }
+
+        public interface Issue601_IData : Issue601_IBaseData
+        {
+            string DateTimeStr => DateTimeUtc.ToString("O");
+        }
+
+        public class Issue601_Data : Issue601_IData
+        {
+            public DateTime DateTimeUtc { get; set; }
+            public string OtherStr => DateTimeUtc.ToString("D");
+        }
+
+        // Issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/601
+        // A property whose only implementation is a C# 8+ default interface member (declared and
+        // bodied on the interface, not overridden by the concrete class) must still be resolvable
+        // by name, even though it's invisible to Type.GetProperties() on the concrete class.
+        [Fact]
+        public void Issue601_DefaultInterfaceMemberPropertyIsResolved()
+        {
+            var handlebars = Handlebars.Create();
+            var template = handlebars.Compile("{{DateTimeStr}}|{{OtherStr}}");
+
+            var data = new Issue601_Data { DateTimeUtc = new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc) };
+            Issue601_IData dataAsInterface = data;
+            var result = template(data);
+
+            Assert.Equal($"{dataAsInterface.DateTimeStr}|{data.OtherStr}", result);
+        }
+
+        // Issue: https://github.com/Handlebars-Net/Handlebars.Net/issues/601
+        // Enumerating a POCO's members (e.g. via {{#each this}}) must also surface
+        // default-interface-member-backed properties, not just class-declared ones.
+        [Fact]
+        public void Issue601_DefaultInterfaceMemberPropertyIsEnumerated()
+        {
+            var handlebars = Handlebars.Create();
+            var template = handlebars.Compile("{{#each this}}{{@key}}={{this}};{{/each}}");
+
+            var data = new Issue601_Data { DateTimeUtc = new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc) };
+            Issue601_IData dataAsInterface = data;
+            var result = template(data);
+
+            Assert.Contains($"DateTimeStr={dataAsInterface.DateTimeStr};", result);
+            Assert.Contains($"OtherStr={data.OtherStr};", result);
+        }
+
         private static void RegisterStringEqualityBlockHelper(IHandlebars handlebars)
         {
             handlebars.RegisterHelper("StringEqualityBlockHelper", (output, options, context, arguments) =>

--- a/source/Handlebars/MemberAccessors/ReflectionMemberAccessor.cs
+++ b/source/Handlebars/MemberAccessors/ReflectionMemberAccessor.cs
@@ -135,6 +135,15 @@ namespace HandlebarsDotNet.MemberAccessors
                         string.Equals(o.Name, name.LowerInvariant, StringComparison.OrdinalIgnoreCase)
                 );
 
+                // Properties implemented purely as C# 8+ default interface members (no override on the
+                // concrete class) don't appear via reflection on the class itself, only on the interface.
+                property ??= type.GetInterfaces()
+                    .SelectMany(o => o.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+                    .FirstOrDefault(o =>
+                        o.GetIndexParameters().Length == 0 &&
+                        string.Equals(o.Name, name.LowerInvariant, StringComparison.OrdinalIgnoreCase)
+                    );
+
                 if (property != null)
                 {
                     return (Func<object, object>) CreateGetDelegateMethodInfo

--- a/source/Handlebars/ObjectDescriptors/ObjectDescriptorProvider.cs
+++ b/source/Handlebars/ObjectDescriptors/ObjectDescriptorProvider.cs
@@ -42,12 +42,20 @@ namespace HandlebarsDotNet.ObjectDescriptors
                 {
                     var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
                         .Where(o => o.CanRead && o.GetIndexParameters().Length == 0);
-                    
+
+                    // Properties implemented purely as C# 8+ default interface members (no override on the
+                    // concrete class) don't appear via reflection on the class itself, only on the interface.
+                    var interfaceProperties = type.GetInterfaces()
+                        .SelectMany(o => o.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                        .Where(o => o.CanRead && o.GetIndexParameters().Length == 0);
+
                     var fields = type.GetFields(BindingFlags.Public | BindingFlags.Instance);
                     return properties
+                        .Concat(interfaceProperties)
                         .Cast<MemberInfo>()
                         .Concat(fields)
                         .Select(o => o.Name)
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
                         .Select(o => ChainSegment.Create(o))
                         .ToArray();
                 });


### PR DESCRIPTION
## Summary
- `Type.GetProperties()` on a concrete class doesn't surface properties whose only implementation is a C# 8+ default interface member (declared and bodied on an interface, not overridden by the class). Both `{{PropertyName}}` lookup (`ReflectionMemberAccessor`) and property enumeration (`ObjectDescriptorProvider`, used by `{{#each this}}`) now also scan the instance type's implemented interfaces as a fallback.
- Verified experimentally that `PropertyInfo.GetValue`/`CreateDelegate` on an interface-declared property correctly dispatches to the default implementation for a concrete instance, so no change was needed to the existing delegate-binding code.

Fixes #601.

## Test plan
- [x] Added `Issue601_DefaultInterfaceMemberPropertyIsResolved` and `Issue601_DefaultInterfaceMemberPropertyIsEnumerated` in `IssueTests.cs`, reproducing the exact interface/class shape from the issue.
- [x] Full test suite passes: 1906/1906, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)