### PR TITLE
Add net10.0 target framework

### DIFF
--- a/source/Handlebars/Handlebars.csproj
+++ b/source/Handlebars/Handlebars.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Handlebars</AssemblyName>
     <ProjectGuid>9822C7B8-7E51-42BC-9A49-72A10491B202</ProjectGuid>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <Version>2.0.0</Version>
     <RootNamespace>HandlebarsDotNet</RootNamespace>
     <SignAssembly Condition="'$(ShouldSignAssembly)' == 'true'">true</SignAssembly>


### PR DESCRIPTION
## Summary
- Adds `net10.0` to the `Handlebars` library's `TargetFrameworks`, alongside the existing `netstandard2.0`, `netstandard2.1`, and `net8.0` targets.
- CI already builds/tests against the net10.0 SDK and the Test/Benchmark projects already target `net10.0`, but the published library itself was missing the target — this closes that gap.

Fixes #659

## Test plan
- [x] `dotnet build -c Release` succeeds for all four target frameworks
- [x] `dotnet test` passes (1912/1912) on net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)