### PR TITLE
perf: render-path optimizations (-21-36% render time, -50% allocations)

### DIFF
--- a/source/Handlebars/BindingContext.cs
+++ b/source/Handlebars/BindingContext.cs
@@ -66,6 +66,7 @@ namespace HandlebarsDotNet
         private void Initialize()
         {
             Root = ParentContext?.Root ?? this;
+            HasFrameHelpers = ParentContext?.HasFrameHelpers ?? false;
             
             ContextDataObject.AddOrReplace(ChainSegment.Root, Root.Value, out WellKnownVariables[(int) WellKnownVariable.Root]);
 
@@ -117,8 +118,16 @@ namespace HandlebarsDotNet
         internal CascadeIndex<string, IHelperDescriptor<BlockHelperOptions>, StringEqualityComparer> BlockHelpers { get; }
 
         internal TemplateDelegate? PartialBlockTemplate { get; set; }
-        
+
         internal short PartialDepth { get; set; }
+
+        /// <summary>
+        /// <c>true</c> once any code obtained this frame's (or an ancestor frame's) helper
+        /// registries for writing — see <see cref="IHelpersRegistry"/>. Until then the
+        /// per-frame helper chain is known to be empty, letting hot paths
+        /// (<see cref="Helpers.LateBindHelperDescriptor"/>) skip the cascade lookup entirely.
+        /// </summary>
+        internal bool HasFrameHelpers { get; set; }
 
         public object? Value { get; set; }
 
@@ -203,8 +212,16 @@ namespace HandlebarsDotNet
             }
         }
 
-        IIndexed<string, IHelperDescriptor<HelperOptions>> IHelpersRegistry.GetHelpers() => Helpers;
+        IIndexed<string, IHelperDescriptor<HelperOptions>> IHelpersRegistry.GetHelpers()
+        {
+            HasFrameHelpers = true;
+            return Helpers;
+        }
 
-        IIndexed<string, IHelperDescriptor<BlockHelperOptions>> IHelpersRegistry.GetBlockHelpers() => BlockHelpers;
+        IIndexed<string, IHelperDescriptor<BlockHelperOptions>> IHelpersRegistry.GetBlockHelpers()
+        {
+            HasFrameHelpers = true;
+            return BlockHelpers;
+        }
     }
 }

--- a/source/Handlebars/Decorators/BlockDecoratorOptions.cs
+++ b/source/Handlebars/Decorators/BlockDecoratorOptions.cs
@@ -84,8 +84,8 @@ namespace HandlebarsDotNet
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Template(in EncodedTextWriter writer, BindingContext context) => OriginalTemplate(writer, context);
         
-        IIndexed<string, IHelperDescriptor<HelperOptions>> IHelpersRegistry.GetHelpers() => Frame.Helpers;
+        IIndexed<string, IHelperDescriptor<HelperOptions>> IHelpersRegistry.GetHelpers() => ((IHelpersRegistry) Frame).GetHelpers();
 
-        IIndexed<string, IHelperDescriptor<BlockHelperOptions>> IHelpersRegistry.GetBlockHelpers() => Frame.BlockHelpers;
+        IIndexed<string, IHelperDescriptor<BlockHelperOptions>> IHelpersRegistry.GetBlockHelpers() => ((IHelpersRegistry) Frame).GetBlockHelpers();
     }
 }

--- a/source/Handlebars/Decorators/DecoratorOptions.cs
+++ b/source/Handlebars/Decorators/DecoratorOptions.cs
@@ -25,8 +25,8 @@ namespace HandlebarsDotNet
         
         public PathInfo Name { get; }
         
-        IIndexed<string, IHelperDescriptor<HelperOptions>> IHelpersRegistry.GetHelpers() => Frame.Helpers;
+        IIndexed<string, IHelperDescriptor<HelperOptions>> IHelpersRegistry.GetHelpers() => ((IHelpersRegistry) Frame).GetHelpers();
 
-        IIndexed<string, IHelperDescriptor<BlockHelperOptions>> IHelpersRegistry.GetBlockHelpers() => Frame.BlockHelpers;
+        IIndexed<string, IHelperDescriptor<BlockHelperOptions>> IHelpersRegistry.GetBlockHelpers() => ((IHelpersRegistry) Frame).GetBlockHelpers();
     }
 }

--- a/source/Handlebars/Extensions/EnumerableExtensions.cs
+++ b/source/Handlebars/Extensions/EnumerableExtensions.cs
@@ -12,7 +12,14 @@ namespace HandlebarsDotNet
         public static bool Any(this IEnumerable builder)
         {
             var enumerator = builder.GetEnumerator();
-            return enumerator.MoveNext();
+            try
+            {
+                return enumerator.MoveNext();
+            }
+            finally
+            {
+                (enumerator as IDisposable)?.Dispose();
+            }
         }
         
         public static bool IsOneOf<TSource, TExpected>(this IEnumerable<TSource> source)

--- a/source/Handlebars/HandlebarsUtils.cs
+++ b/source/Handlebars/HandlebarsUtils.cs
@@ -40,11 +40,25 @@ namespace HandlebarsDotNet
                     return IsFalsyJsonElement(element, includeZero);
             }
 
-            if (IsNumber(value) && !includeZero)
+            if (includeZero) return false;
+
+            // Typed zero checks in likelihood order; avoids IsNumber's isinst cascade
+            // followed by Convert.ToBoolean's IConvertible dispatch on the hot path.
+            return value switch
             {
-                return !Convert.ToBoolean(value);
-            }
-            return false;
+                int i => i == 0,
+                long l => l == 0L,
+                double d => d == 0d,
+                float f => f == 0f,
+                decimal m => m == 0m,
+                byte b8 => b8 == 0,
+                sbyte s8 => s8 == 0,
+                short s16 => s16 == 0,
+                ushort u16 => u16 == 0,
+                uint u32 => u32 == 0u,
+                ulong u64 => u64 == 0ul,
+                _ => false
+            };
         }
 
         private static bool IsFalsyJsonElement(JsonElement element, bool includeZero)
@@ -84,23 +98,13 @@ namespace HandlebarsDotNet
                     || (element.ValueKind == JsonValueKind.Array && element.GetArrayLength() == 0);
             }
 
+            // O(1) emptiness checks that avoid allocating an enumerator for the common
+            // collection shapes; the IEnumerable fallback boxes List<T>-style struct enumerators.
+            if (value is ICollection collection) return collection.Count == 0;
+
             return value is IEnumerable enumerable && !enumerable.Any();
         }
 
-        private static bool IsNumber([NotNullWhen(true)] object? value)
-        {
-            return value is sbyte
-                || value is byte
-                || value is short
-                || value is ushort
-                || value is int
-                || value is uint
-                || value is long
-                || value is ulong
-                || value is float
-                || value is double
-                || value is decimal;
-        }
     }
 }
 

--- a/source/Handlebars/Helpers/BlockHelpers/LateBindBlockHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/BlockHelpers/LateBindBlockHelperDescriptor.cs
@@ -16,7 +16,9 @@ namespace HandlebarsDotNet.Helpers.BlockHelpers
 
         public void Invoke(in EncodedTextWriter output, in BlockHelperOptions options, in Context context, in Arguments arguments)
         {
-            if(options.Frame.BlockHelpers.TryGetValue(Name, out var contextHelper))
+            // Frame-local helpers only exist once something wrote to a frame's helper registry
+            // (decorators / in-render registration); skip the cascade walk in the common case.
+            if(options.Frame.HasFrameHelpers && options.Frame.BlockHelpers.TryGetValue(Name, out var contextHelper))
             {
                 contextHelper.Invoke(options, context, arguments);
                 return;

--- a/source/Handlebars/Helpers/BlockHelpers/LateBindBlockHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/BlockHelpers/LateBindBlockHelperDescriptor.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Runtime.CompilerServices;
 using HandlebarsDotNet.Collections;
 using HandlebarsDotNet.PathStructure;
 
@@ -5,6 +7,12 @@ namespace HandlebarsDotNet.Helpers.BlockHelpers
 {
     public sealed class LateBindBlockHelperDescriptor : IHelperDescriptor<BlockHelperOptions>
     {
+        // See LateBindHelperDescriptor: ObservableList.Count locks per call, so the
+        // "are there helper resolvers" check is cached behind an observer-maintained flag.
+        private ObservableList<IHelperResolver>? _observedResolvers;
+        private IObserver<IObservableEvent<IHelperResolver>>? _observerRoot; // strong root: ObservableList holds observers weakly
+        private volatile bool _hasResolvers;
+
         public LateBindBlockHelperDescriptor(string name) => Name = name;
 
         public PathInfo Name { get; }
@@ -23,11 +31,11 @@ namespace HandlebarsDotNet.Helpers.BlockHelpers
                 contextHelper.Invoke(options, context, arguments);
                 return;
             }
-            
-            // TODO: add cache
+
             var configuration = options.Frame.Configuration;
             var helperResolvers = (ObservableList<IHelperResolver>) configuration.HelperResolvers;
-            if(helperResolvers.Count != 0)
+            if (!ReferenceEquals(_observedResolvers, helperResolvers)) ObserveResolvers(helperResolvers);
+            if (_hasResolvers)
             {
                 for (var index = 0; index < helperResolvers.Count; index++)
                 {
@@ -40,6 +48,20 @@ namespace HandlebarsDotNet.Helpers.BlockHelpers
 
             configuration.BlockHelpers["blockHelperMissing"]!.Value
                 .Invoke(output, options, context, arguments);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ObserveResolvers(ObservableList<IHelperResolver> resolvers)
+        {
+            // Subscribe before snapshotting Count so a concurrent Add can never be missed;
+            // duplicate subscriptions from a racing first call are benign (same flag).
+            var observer = ObserverBuilder<IObservableEvent<IHelperResolver>>.Create(this)
+                .OnEvent<AddedObservableEvent<IHelperResolver>>((_, state) => state._hasResolvers = true)
+                .Build();
+            resolvers.Subscribe(observer);
+            _observerRoot = observer;
+            if (resolvers.Count != 0) _hasResolvers = true;
+            _observedResolvers = resolvers;
         }
     }
 }

--- a/source/Handlebars/Helpers/LateBindHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/LateBindHelperDescriptor.cs
@@ -13,7 +13,9 @@ namespace HandlebarsDotNet.Helpers
         {
             var bindingContext = options.Frame;
 
-            if(options.Frame.Helpers.TryGetValue(Name, out var contextHelper))
+            // Frame-local helpers only exist once something wrote to a frame's helper registry
+            // (decorators / in-render registration); skip the cascade walk in the common case.
+            if(bindingContext.HasFrameHelpers && bindingContext.Helpers.TryGetValue(Name, out var contextHelper))
             {
                 return contextHelper.Invoke(options, context, arguments);
             }

--- a/source/Handlebars/Helpers/LateBindHelperDescriptor.cs
+++ b/source/Handlebars/Helpers/LateBindHelperDescriptor.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Runtime.CompilerServices;
 using HandlebarsDotNet.Collections;
 using HandlebarsDotNet.PathStructure;
 
@@ -5,6 +7,13 @@ namespace HandlebarsDotNet.Helpers
 {
     public sealed class LateBindHelperDescriptor : IHelperDescriptor<HelperOptions>
     {
+        // ObservableList.Count takes a ReaderWriterLockSlim per call, and this descriptor runs
+        // for every simple {{name}} on every render — so the "are there helper resolvers" check
+        // is cached in a flag kept up to date by subscribing to the (append-only) resolver list.
+        private ObservableList<IHelperResolver>? _observedResolvers;
+        private IObserver<IObservableEvent<IHelperResolver>>? _observerRoot; // strong root: ObservableList holds observers weakly
+        private volatile bool _hasResolvers;
+
         public LateBindHelperDescriptor(string name) => Name = name;
 
         public PathInfo Name { get; }
@@ -19,11 +28,11 @@ namespace HandlebarsDotNet.Helpers
             {
                 return contextHelper.Invoke(options, context, arguments);
             }
-            
-            // TODO: add cache
+
             var configuration = options.Frame.Configuration;
             var helperResolvers = (ObservableList<IHelperResolver>) configuration.HelperResolvers;
-            if (helperResolvers.Count != 0)
+            if (!ReferenceEquals(_observedResolvers, helperResolvers)) ObserveResolvers(helperResolvers);
+            if (_hasResolvers)
             {
                 var targetType = arguments.Length > 0 ? arguments[0]!.GetType() : null;
                 for (var index = 0; index < helperResolvers.Count; index++)
@@ -37,13 +46,27 @@ namespace HandlebarsDotNet.Helpers
 
             var value = PathResolver.ResolvePath(bindingContext, Name);
             if (!(value is UndefinedBindingResult)) return value;
-            
+
             return configuration.Helpers["helperMissing"]!.Value.Invoke(options, context, arguments);
         }
 
         public void Invoke(in EncodedTextWriter output, in HelperOptions options, in Context context, in Arguments arguments)
         {
             output.Write(Invoke(options, context, arguments));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ObserveResolvers(ObservableList<IHelperResolver> resolvers)
+        {
+            // Subscribe before snapshotting Count so a concurrent Add can never be missed;
+            // duplicate subscriptions from a racing first call are benign (same flag).
+            var observer = ObserverBuilder<IObservableEvent<IHelperResolver>>.Create(this)
+                .OnEvent<AddedObservableEvent<IHelperResolver>>((_, state) => state._hasResolvers = true)
+                .Build();
+            resolvers.Subscribe(observer);
+            _observerRoot = observer;
+            if (resolvers.Count != 0) _hasResolvers = true;
+            _observedResolvers = resolvers;
         }
     }
 }

--- a/source/Handlebars/IO/PolledStringWriter.cs
+++ b/source/Handlebars/IO/PolledStringWriter.cs
@@ -7,7 +7,11 @@ namespace HandlebarsDotNet
 {
     public class ReusableStringWriter : StringWriter
     {
-        private static readonly InternalObjectPool<ReusableStringWriter, Policy> Pool = new InternalObjectPool<ReusableStringWriter, Policy>(new Policy(16));
+        // Retain up to 32K chars (64KB, below the LOH threshold) so that templates producing
+        // typical page-sized output keep their grown StringBuilder across renders. The previous
+        // 4096-char limit made any render larger than 4KB discard the writer, forcing every
+        // subsequent render to re-grow a fresh StringBuilder(16) chunk by chunk.
+        private static readonly InternalObjectPool<ReusableStringWriter, Policy> Pool = new InternalObjectPool<ReusableStringWriter, Policy>(new Policy(16, 32 * 1024));
         
         private IFormatProvider _formatProvider = null!;
 

--- a/source/Handlebars/IO/SafeStrings.cs
+++ b/source/Handlebars/IO/SafeStrings.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace HandlebarsDotNet.IO
 {
@@ -16,15 +17,26 @@ namespace HandlebarsDotNet.IO
         private static readonly ConditionalWeakTable<string, object> Marked = new();
         private static readonly object Sentinel = new();
 
+        // Marking only ever happens when a helper's captured output is written (ReturnInvoke).
+        // Most applications never mark a single string, yet IsSafe sits on the hot path of every
+        // string written to output — so keep a global "has anything ever been marked" latch to
+        // skip the ConditionalWeakTable probe entirely until the first Mark. The latch is written
+        // with release semantics after the table entry exists, so a true reader always observes
+        // the corresponding table entry; a stale false reader merely re-encodes on the same
+        // thread-interleaving that was already possible before the mark completed.
+        private static bool _anyMarked;
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Mark(string value)
         {
             if (value.Length == 0) return value;
             Marked.GetValue(value, _ => Sentinel);
+            Volatile.Write(ref _anyMarked, true);
             return value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsSafe(string value) => value.Length == 0 || Marked.TryGetValue(value, out _);
+        public static bool IsSafe(string value)
+            => value.Length == 0 || (Volatile.Read(ref _anyMarked) && Marked.TryGetValue(value, out _));
     }
 }

--- a/source/Handlebars/ObjectDescriptors/ObjectDescriptorFactory.cs
+++ b/source/Handlebars/ObjectDescriptors/ObjectDescriptorFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using HandlebarsDotNet.Collections;
 using HandlebarsDotNet.EqualityComparers;
 using HandlebarsDotNet.Runtime;
@@ -25,18 +26,31 @@ namespace HandlebarsDotNet.ObjectDescriptors
 
         private readonly IObserver<IObservableEvent<IObjectDescriptorProvider>> _observer;
 
+        private int _version;
+
         public static ObjectDescriptorFactory? Current => AmbientContext.Current?.ObjectDescriptorFactory;
-        
+
+        /// <summary>
+        /// Monotonic stamp bumped whenever the provider set changes; lets external
+        /// per-call-site descriptor caches (see <see cref="PathStructure.ChainSegment"/>)
+        /// detect that previously resolved descriptors may be stale.
+        /// </summary>
+        internal int Version => Volatile.Read(ref _version);
+
         public ObjectDescriptorFactory(ObservableList<IObjectDescriptorProvider>? providers = null)
         {
             _providers = new ObservableList<IObjectDescriptorProvider>();
-             
+
             if (providers != null) Append(providers);
-            
-            _observer = ObserverBuilder<IObservableEvent<IObjectDescriptorProvider>>.Create(_descriptorsCache)
-                .OnEvent<AddedObservableEvent<IObjectDescriptorProvider>>((@event, state) => state.Clear())
+
+            _observer = ObserverBuilder<IObservableEvent<IObjectDescriptorProvider>>.Create(this)
+                .OnEvent<AddedObservableEvent<IObjectDescriptorProvider>>((@event, state) =>
+                {
+                    state._descriptorsCache.Clear();
+                    Interlocked.Increment(ref state._version);
+                })
                 .Build();
-            
+
             _providers.Subscribe(this);
         }
 

--- a/source/Handlebars/PathStructure/ChainSegment.cs
+++ b/source/Handlebars/PathStructure/ChainSegment.cs
@@ -93,6 +93,63 @@ namespace HandlebarsDotNet.PathStructure
         
         internal readonly WellKnownVariable WellKnownVariable;
 
+        // Monomorphic inline cache for render-time member access (see PathResolver.TryAccessMember):
+        // most call sites see one instance type under one descriptor factory, so a single
+        // immutable (factory, version, type) -> descriptor entry avoids the ambient-context
+        // probe plus type-keyed dictionary lookup on every access. Reference assignment keeps
+        // readers consistent; a stale entry is invalidated by the factory version stamp.
+        private DescriptorCacheEntry? _descriptorCache;
+
+        private sealed class DescriptorCacheEntry
+        {
+            public readonly ObjectDescriptors.ObjectDescriptorFactory Factory;
+            public readonly int Version;
+            public readonly Type Type;
+            public readonly ObjectDescriptors.ObjectDescriptor Descriptor;
+
+            public DescriptorCacheEntry(ObjectDescriptors.ObjectDescriptorFactory factory, int version, Type type, ObjectDescriptors.ObjectDescriptor descriptor)
+            {
+                Factory = factory;
+                Version = version;
+                Type = type;
+                Descriptor = descriptor;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal ObjectDescriptors.ObjectDescriptor GetDescriptorFor(object instance)
+        {
+            var factory = ObjectDescriptors.ObjectDescriptorFactory.Current;
+            if (factory == null) return ObjectDescriptors.ObjectDescriptor.Empty;
+
+            var type = instance.GetType();
+            var cache = _descriptorCache;
+            if (cache != null
+                && ReferenceEquals(cache.Factory, factory)
+                && ReferenceEquals(cache.Type, type)
+                && cache.Version == factory.Version)
+            {
+                return cache.Descriptor;
+            }
+
+            return GetDescriptorSlow(factory, type);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private ObjectDescriptors.ObjectDescriptor GetDescriptorSlow(ObjectDescriptors.ObjectDescriptorFactory factory, Type type)
+        {
+            // Read the version before resolving so a concurrent provider registration can only
+            // produce an entry that immediately misses (never a stale entry stamped fresh).
+            var version = factory.Version;
+            if (!factory.TryGetDescriptor(type, out var descriptor))
+            {
+                descriptor = ObjectDescriptors.ObjectDescriptor.Empty;
+            }
+
+            _descriptorCache = new DescriptorCacheEntry(factory, version, type, descriptor);
+            return descriptor;
+        }
+
         /// <summary>
         /// Returns string representation of current <see cref="ChainSegment"/>
         /// </summary>

--- a/source/Handlebars/PathStructure/PathResolver.cs
+++ b/source/Handlebars/PathStructure/PathResolver.cs
@@ -12,7 +12,6 @@ namespace HandlebarsDotNet.PathStructure
             if (pathInfo.IsPureThis) return context.Value;
             
             var instance = context.Value;
-            var throwOnUnresolvedBindingExpression = context.Configuration.ThrowOnUnresolvedBindingExpression;
 
             var segments = pathInfo.Segments;
             for (var segmentIndex = 0; segmentIndex < segments.Length; segmentIndex++)
@@ -21,15 +20,15 @@ namespace HandlebarsDotNet.PathStructure
                 if (segment.IsThis) continue;
                 if (segment.IsParent)
                 {
-                    context = context.ParentContext!;
-                    if (context == null!)
+                    var parent = context.ParentContext;
+                    if (parent == null)
                     {
                         instance = UndefinedBindingResult.Create("..");
                         goto undefined;
                     }
 
+                    context = parent;
                     instance = context.Value;
-                    throwOnUnresolvedBindingExpression = context.Configuration.ThrowOnUnresolvedBindingExpression;
                     continue;
                 }
 
@@ -52,7 +51,9 @@ namespace HandlebarsDotNet.PathStructure
             return instance;
             
             undefined:
-            if (throwOnUnresolvedBindingExpression)
+            // Only consult configuration on the (rare) unresolved branch; reading it eagerly
+            // costs two dispatched property reads per resolve on the hot path.
+            if (context.Configuration.ThrowOnUnresolvedBindingExpression)
             {
                 Throw.Undefined(pathInfo, (UndefinedBindingResult) instance);
             }

--- a/source/Handlebars/PathStructure/PathResolver.cs
+++ b/source/Handlebars/PathStructure/PathResolver.cs
@@ -93,8 +93,15 @@ namespace HandlebarsDotNet.PathStructure
             }
             
             chainSegment = ResolveMemberName(instance, chainSegment, context.Configuration);
-            
-            return new ObjectAccessor(instance).TryGetValue(chainSegment, out value);
+
+            var accessor = chainSegment.GetDescriptorFor(instance).MemberAccessor;
+            if (accessor == null)
+            {
+                value = null!;
+                return false;
+            }
+
+            return accessor.TryGetValue(instance, chainSegment, out value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/source/Handlebars/Pools/BindingContext.Pool.cs
+++ b/source/Handlebars/Pools/BindingContext.Pool.cs
@@ -48,6 +48,7 @@ namespace HandlebarsDotNet
                 {
                     item.Configuration = null!;
 
+                    item.HasFrameHelpers = false;
                     item.Root = null!;
                     item.Value = null!;
                     item.ParentContext = null;


### PR DESCRIPTION
Seven render-path optimizations, found via profiling + per-hypothesis benchmarking against a pinned baseline. Each commit was validated independently: the full test suite (1912 tests) passes after every commit, and every number below comes from BenchmarkDotNet MediumRun A/B runs on the same machine (noisy cases re-run with `--launchCount 3-4`).

## Results vs baseline

| Suite | Baseline | This PR | Time | Alloc |
|---|---|---|---|---|
| RenderToString clean | 10.49 µs / 30.2 KB | 7.48 µs / 13.4 KB | **−29%** | **−56%** |
| RenderToString html | 13.15 µs / 33.4 KB | 10.37 µs / 16.7 KB | **−21%** | **−50%** |
| RenderList 100 (object) | 18.95 µs | 12.16 µs | **−36%** | — |
| RenderList 1000 (dictionary) | 191.3 µs | 126.7 µs | **−34%** | — |
| RenderNested 20 (object) | 19.18 µs | 12.44 µs | **−35%** | — |
| RenderSimple (object) | 636 ns | 431 ns | **−32%** | — |
| EndToEnd | 26.1 µs | 23.5 µs | −10% | — |
| LargeArray / Compilation / Execution | — | — | flat | flat |

## The changes

- **Cache helper-resolver presence in late-bind descriptors.** `ObservableList<T>.Count` acquires a `ReaderWriterLockSlim` per call, and `LateBindHelperDescriptor` checked it once per `{{name}}` per render — every dot-free segment routes through the late-bind path, so loops paid hundreds of lock acquisitions per render. The descriptors now subscribe once to the append-only resolver list and keep a volatile flag; resolvers registered after compile still take effect.
- **Retain up to 32K chars in the pooled `ReusableStringWriter`.** Outputs over 4096 chars caused the pooled writer to be discarded every render, re-growing a fresh `StringBuilder(16)` chunk by chunk. This was most of RenderToString's allocations.
- **Monomorphic descriptor cache on `ChainSegment`.** Dotted member access re-resolved the instance's `ObjectDescriptor` through the ambient context + type-keyed lookup on every segment per render. Each segment now holds an immutable `(factory, version, type) → descriptor` entry; `ObjectDescriptorFactory` gained a version stamp bumped on provider registration so entries self-invalidate.
- **Skip the frame-helper cascade walk when no frame helpers exist.** `BindingContext` tracks whether any frame in the ancestry ever exposed its helper registries for writing (decorators / in-render registration); until then the late-bind descriptors skip the per-invocation cascade lookup.
- **Skip the `ConditionalWeakTable` probe in `SafeStrings` until the first `Mark`.** Applications that never produce safe-marked strings no longer pay a CWT lookup per string written.
- **Read `ThrowOnUnresolvedBindingExpression` only on the unresolved branch** instead of two dispatched config reads per resolve.
- **Cheaper falsy checks**: typed zero comparisons replace the `IsNumber` isinst cascade + `Convert.ToBoolean` IConvertible dispatch; `IsFalsyOrEmpty` gets an O(1) `ICollection.Count` fast path (avoids boxing struct enumerators); `Any()` now disposes the enumerator.

## Tradeoffs / notes

- The `ChainSegment` cache allocates a small entry when the observed instance type changes, so heterogeneous collections with dotted access thrash it (~32 B per type flip); homogeneous data allocates once per segment ever.
- `HasFrameHelpers` is set conservatively whenever a frame's registry is obtained for writing and inherits down the frame chain; decorator and in-render registration semantics are preserved by the existing test coverage.
- Documented-but-not-implemented follow-ups: per-`{{#each}}`-site iterator cache, `FixedSizeDictionary` idiv→mask (analysis says ~1%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
