### PR TITLE
perf: 83-88% faster template compilation via NoInlining JIT entry points

### DIFF
--- a/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
@@ -68,10 +68,15 @@ namespace HandlebarsDotNet.Compiler
                 }
 
                 var bindingContext = CompilationContext.Args.BindingContext;
+                var options = New(() => new HelperOptions(pathInfo, bindingContext));
+                var contextValue = New(() => new Context(bindingContext));
+                var args = New(() => new Arguments(0));
                 var textWriter = CompilationContext.Args.EncodedWriter;
-                // Single NoInlining entry point instead of inline options/context/arguments
-                // construction + dispatch — see CompiledHelperInvokers for rationale.
-                return Call(() => CompiledHelperInvokers.WriteInvoke(textWriter, helper, pathInfo, bindingContext));
+                // Kept inline (unlike the plain-path statement route below): this is the
+                // hottest render-time shape, and routing it through a NoInlining entry point
+                // costs ~2ns per value per render. Compile cost of this shape is moderate
+                // because the interface dispatch below cannot be inline-expanded by the JIT.
+                return Call(() => helper.Value.Invoke(textWriter, options, contextValue, args));
             }
 
             var writer = CompilationContext.Args.EncodedWriter;

--- a/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
@@ -9,6 +9,10 @@ namespace HandlebarsDotNet.Compiler
 {
     internal class PathBinder : HandlebarsExpressionVisitor
     {
+        private static readonly System.Reflection.MethodInfo WriteObjectToMethod =
+            typeof(EncodedTextWriter).GetMethod("WriteObjectTo",
+                System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!;
+
         private CompilationContext CompilationContext { get; }
 
         public PathBinder(CompilationContext compilationContext)
@@ -64,16 +68,19 @@ namespace HandlebarsDotNet.Compiler
                 }
 
                 var bindingContext = CompilationContext.Args.BindingContext;
-                var options = New(() => new HelperOptions(pathInfo, bindingContext));
-                var contextValue = New(() => new Context(bindingContext));
-                var args = New(() => new Arguments(0));
                 var textWriter = CompilationContext.Args.EncodedWriter;
-                return Call(() => helper.Value.Invoke(textWriter, options, contextValue, args));
+                // Single NoInlining entry point instead of inline options/context/arguments
+                // construction + dispatch — see CompiledHelperInvokers for rationale.
+                return Call(() => CompiledHelperInvokers.WriteInvoke(textWriter, helper, pathInfo, bindingContext));
             }
 
             var writer = CompilationContext.Args.EncodedWriter;
             var value = Arg<object>(Visit(sex.Body));
-            return writer.Call(o => o.Write<object>(value));
+            // Emit as a static call with the writer in (in-)argument position: LambdaCompiler
+            // compiles an instance call on the struct parameter whose argument is a call
+            // result dramatically slower (~0.3ms+ per statement) than the equivalent
+            // static-call shape used by the helper invocation route.
+            return Expression.Call(WriteObjectToMethod, writer.Expression, value.Expression);
         }
 
         protected override Expression VisitPathExpression(PathExpression pex)
@@ -119,10 +126,9 @@ namespace HandlebarsDotNet.Compiler
                 }
             }
 
-            var options = New(() => new HelperOptions(pathInfo, bindingContext));
-            var context = New(() => new Context(bindingContext));
-            var argumentsArg = New(() => new Arguments(0));
-            return Call(() => helper.Value.Invoke(options, context, argumentsArg));
+            // Single NoInlining entry point instead of inline options/context/arguments
+            // construction + dispatch — see CompiledHelperInvokers for rationale.
+            return Call(() => CompiledHelperInvokers.Invoke(helper, pathInfo, bindingContext));
         }
     }
 }

--- a/source/Handlebars/Helpers/CompiledHelperInvokers.cs
+++ b/source/Handlebars/Helpers/CompiledHelperInvokers.cs
@@ -14,16 +14,6 @@ namespace HandlebarsDotNet.Helpers
     internal static class CompiledHelperInvokers
     {
         [MethodImpl(MethodImplOptions.NoInlining)]
-        internal static void WriteInvoke(
-            in EncodedTextWriter writer,
-            Ref<IHelperDescriptor<HelperOptions>> helper,
-            PathInfo pathInfo,
-            BindingContext bindingContext)
-        {
-            helper.Value.Invoke(writer, new HelperOptions(pathInfo, bindingContext), new Context(bindingContext), new Arguments(0));
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static object? Invoke(
             Ref<IHelperDescriptor<HelperOptions>> helper,
             PathInfo pathInfo,

--- a/source/Handlebars/Helpers/CompiledHelperInvokers.cs
+++ b/source/Handlebars/Helpers/CompiledHelperInvokers.cs
@@ -1,0 +1,35 @@
+using System.Runtime.CompilerServices;
+using HandlebarsDotNet.PathStructure;
+using HandlebarsDotNet.Runtime;
+
+namespace HandlebarsDotNet.Helpers
+{
+    /// <summary>
+    /// Static entry points emitted by the compiler for helper-literal statements
+    /// ({{name}} with no arguments). NoInlining keeps template JIT fast: dynamic methods
+    /// are compiled at CreateDelegate, and expanding the options/context/arguments
+    /// construction plus dispatch into every call site multiplied template JIT cost.
+    /// These methods are JIT-compiled once per process; templates emit one thin call.
+    /// </summary>
+    internal static class CompiledHelperInvokers
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void WriteInvoke(
+            in EncodedTextWriter writer,
+            Ref<IHelperDescriptor<HelperOptions>> helper,
+            PathInfo pathInfo,
+            BindingContext bindingContext)
+        {
+            helper.Value.Invoke(writer, new HelperOptions(pathInfo, bindingContext), new Context(bindingContext), new Arguments(0));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static object? Invoke(
+            Ref<IHelperDescriptor<HelperOptions>> helper,
+            PathInfo pathInfo,
+            BindingContext bindingContext)
+        {
+            return helper.Value.Invoke(new HelperOptions(pathInfo, bindingContext), new Context(bindingContext), new Arguments(0));
+        }
+    }
+}

--- a/source/Handlebars/IO/EncodedTextWriter.cs
+++ b/source/Handlebars/IO/EncodedTextWriter.cs
@@ -114,6 +114,14 @@ namespace HandlebarsDotNet
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public void Write(object? value) => Write<object>(value);
 
+		// Static entry point used by compiled templates ({{expr}} statements). NoInlining is
+		// what makes template compilation fast: dynamic methods are JIT-compiled at
+		// CreateDelegate, and inlining the aggressive-inline Write<object> type-switch and
+		// encoder machinery into every mustache call site multiplied template JIT cost ~6x.
+		// This wrapper is JIT-compiled once per process; templates emit one thin call.
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		internal static void WriteObjectTo(in EncodedTextWriter writer, object? value) => writer.Write<object>(value);
+
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public void Write<T>(T? value)
 		{


### PR DESCRIPTION
Follow-up to #667, targeting the compile path. Template compilation is 83–88% faster; render performance is verified unchanged (that was a hard constraint — one intermediate change that cost ~4% on RenderToString was found by the guardrail benchmarks and walked back).

## Results

| Benchmark | Before | After | Change |
|---|---|---|---|
| Compilation (nested 3-level template) | 10.80 ms | 1.85 ms | **−83%** |
| CompileMany N=10 | 57.7 ms | 6.97 ms | **−88%** |
| CompileMany N=100 | 537.9 ms | 78.1 ms | **−85%** |
| RenderToString clean / html (guardrail, 3-launch A/B) | 7.46 / 10.35 µs | 7.53 / 10.29 µs | within noise |
| RenderSimple / RenderNested / RenderList (guardrail) | — | — | flat to slightly improved |

All 1912 tests pass after each commit.

## Root cause

Profiling showed ~95–99% of compile time inside `Expression.Compile()` → `LambdaCompiler.CreateDelegate`, mostly unmanaged — the Handlebars visitor pipeline is under 4%. Synthetic-tree bisection isolated the driver: **dynamic methods are JIT-compiled eagerly at `CreateDelegate`, and the JIT honors `[AggressiveInlining]` on `EncodedTextWriter.Write<object>` and the type-switch/encoder machinery behind it — inline-expanding all of it into every mustache call site of every template.** A 40-statement template calling an empty-bodied struct method compiles in 0.07 ms; the identical tree shape calling `Write(object)` took 2.9 ms. Template compile cost tracks the fatness of inlined callees, not tree size.

## The change

Emit thin `[MethodImpl(NoInlining)]` static entry points, JIT-compiled once per process instead of re-inlined into every template:

- `EncodedTextWriter.WriteObjectTo(in writer, object?)` for `{{expr}}` statement writes (probe: 40× `{{a.b}}` 13.1 → 1.5 ms/compile)
- `CompiledHelperInvokers.Invoke` for helper-literal path expressions

Zero-argument helper-literal **statements** (`{{name}}` — the hottest render shape) deliberately keep their inline dispatch: routing them through a wrapper cost ~2 ns per value per render (+4% RenderToString clean), and their interface dispatch can't be inline-expanded by the JIT anyway, so their compile cost is moderate. That trade-off is documented in the code.

## Tried and rejected

- **FastExpressionCompiler** (5.4.1 and 4.2.2) as the `IExpressionCompiler` backend: 1315/1912 tests fail with `InvalidProgramException` — invalid IL for these tree shapes (likely the `in`-parameter struct delegates). May be worth an upstream issue.
- Visitor-pass fusion: permanently deprioritized — ~4% ceiling per the profile.

Remaining follow-ups (documented, not implemented): the `{{#if}}` condition route (~63 µs/statement, auto-inlining of the `IsTruthyOrNonEmpty` chain) and helpers-with-arguments (`HelperFunctionBinder`) could get the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
